### PR TITLE
Workflow qualité de code : Ruff (bloquant) + mypy (indicatif)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,71 @@
+name: Quality
+
+# Implements the contract documented in spec/spec-process-cicd-quality.md.
+# Keep the two in sync: any change to triggers, jobs, or gates here
+# should update that spec first, per its Change Management section.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    # Blocking. This job's name is the required status check wired into
+    # branch protection for `main` -- keep it stable ("ruff").
+    name: ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: setup.py
+
+      # ruff + mypy are declared in setup.py's `dev` extra, so the tool
+      # versions CI uses are the same ones `pip install -e ".[dev]"` gives
+      # a contributor locally -- no separate tool-install step, no drift.
+      - name: Install (dev extras)
+        run: pip install -e ".[dev]"
+
+      - name: ruff check
+        run: ruff check --output-format=github .
+
+      - name: ruff format --check
+        run: ruff format --check --diff .
+
+  mypy:
+    # Advisory only: mypy currently reports a known, non-empty error
+    # baseline (see the spec). continue-on-error keeps a regression
+    # visible in the run without blocking merge. Promoting this to a
+    # required check is tracked as fog on the wayfinder map (issue #1).
+    name: mypy (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: setup.py
+
+      - name: Install (dev extras)
+        run: pip install -e ".[dev]"
+
+      - name: mypy
+        run: mypy

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ __pycache__/
 *.egg-info/
 build/
 dist/
-spec/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,24 @@ kind, emission ordering, reference-resolution strategy).
   ingestion report and be skipped, not crash the whole run, unless
   `fail_on_unresolved_reference` is set.
 
+### Lint, format, and types
+
+Ruff and mypy are installed by the `dev` extra. Before pushing, run the same
+checks CI runs (`.github/workflows/quality.yml`, contract in
+`spec/spec-process-cicd-quality.md`):
+
+```bash
+ruff check .            # lint (blocking in CI)
+ruff format --check .   # formatting (blocking in CI); drop --check to apply
+mypy                    # type check over src/ (advisory in CI, not a gate)
+```
+
+`ruff check --fix .` auto-fixes most lint findings. `ruff` config
+(`[tool.ruff]`, line length 100, target `py310`) and `mypy` config
+(`[tool.mypy]`, `src/` only, non-strict) both live in `pyproject.toml`. mypy
+currently has a known non-empty error baseline — see the spec — so a new mypy
+error won't fail CI, but don't add to it.
+
 ## Submitting changes
 
 1. Open an issue or discussion first for anything beyond a small fix, so the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,21 @@ select = ["E", "F", "I", "UP", "B", "C4", "SIM", "RUF"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["datahub_yaml_source"]
+
+[tool.mypy]
+# Advisory only -- the quality workflow runs this job with
+# continue-on-error. Scope is the package itself; tests/ and scripts/ are
+# left out until the src/ signal is clean. Non-strict baseline, with the
+# few low-noise warnings that catch real staleness.
+files = ["src"]
+python_version = "3.10"
+check_untyped_defs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+# acryl-datahub ships partial/absent type information; its generated
+# metadata classes in particular are untyped. Don't let that drown the
+# signal from our own code.
+module = ["datahub.*", "deepdiff.*"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+# Tool configuration only. Packaging is still owned by setup.py (there is
+# deliberately no [build-system] table here); this file exists so Ruff and
+# mypy have the standard home they look for first. See
+# spec/spec-process-cicd-quality.md for the rationale behind each choice.
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+src = ["src", "tests", "scripts"]
+
+[tool.ruff.lint]
+# Pragmatic set for a solo-maintained translation layer: pyflakes/pycodestyle
+# errors (E, F), import sorting (I), pyupgrade (UP), flake8-bugbear (B),
+# flake8-comprehensions (C4), flake8-simplify (SIM) and Ruff's own rules
+# (RUF). Deliberately excludes annotation-completeness (ANN) and the
+# opinionated pylint (PL) families to keep the signal high.
+select = ["E", "F", "I", "UP", "B", "C4", "SIM", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+# Re-export surfaces: an unused import is the point.
+"__init__.py" = ["F401"]
+# Test fixtures embed full DataHub URNs and JSON blobs as string literals;
+# these are legitimately long and not meaningfully breakable. The formatter
+# still enforces 100 cols on everything it can reflow.
+"tests/**" = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["datahub_yaml_source"]

--- a/scripts/generate_json_schema.py
+++ b/scripts/generate_json_schema.py
@@ -54,7 +54,12 @@ from datahub_yaml_source.models import (
 )
 
 OUTPUT_PATH = (
-    Path(__file__).parent.parent / "docs" / "sources" / "yaml" / "schema" / "yaml-metadata.schema.json"
+    Path(__file__).parent.parent
+    / "docs"
+    / "sources"
+    / "yaml"
+    / "schema"
+    / "yaml-metadata.schema.json"
 )
 
 # One entry per `kind:` value, plus the `aspectName:`-keyed passthrough doc.

--- a/scripts/generate_markdown_docs.py
+++ b/scripts/generate_markdown_docs.py
@@ -7,8 +7,9 @@ Usage:
     python scripts/generate_markdown_docs.py
 """
 
+import types
 from pathlib import Path
-from typing import Annotated, Any, Dict, List, Literal, Type, Union, get_args, get_origin
+from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -19,6 +20,7 @@ from datahub_yaml_source.models import (
     AIAgentDependenciesDoc,
     AIAgentDoc,
     AIAgentSourceDoc,
+    AiContextDoc,
     AllowedValueDoc,
     ApiDoc,
     ApiSignatureDoc,
@@ -26,6 +28,8 @@ from datahub_yaml_source.models import (
     AssertionAssertionDoc,
     AssertionDoc,
     AssertionPropertiesDoc,
+    CaveatDetailsDoc,
+    CaveatsAndRecommendationsDoc,
     ChartDoc,
     ChartRef,
     ContainerDoc,
@@ -46,6 +50,7 @@ from datahub_yaml_source.models import (
     DisplayPropertiesDoc,
     DocumentDoc,
     DomainDoc,
+    EthicalConsiderationsDoc,
     FineGrainedLineageDoc,
     ForeignKeyDoc,
     GlossaryNodeDoc,
@@ -53,11 +58,8 @@ from datahub_yaml_source.models import (
     IncidentDoc,
     IncidentSourceDoc,
     IncidentStatusDoc,
-    CaveatDetailsDoc,
-    CaveatsAndRecommendationsDoc,
-    EthicalConsiderationsDoc,
     IntendedUseDoc,
-    AiContextDoc,
+    McpServerDoc,
     MetricDoc,
     MetricRef,
     MLFeatureDoc,
@@ -74,7 +76,6 @@ from datahub_yaml_source.models import (
     MLModelSourceCodeDoc,
     MLPrimaryKeyDoc,
     MLPrimaryKeyRef,
-    McpServerDoc,
     OwnerEntry,
     QueryDoc,
     QuerySubjectRef,
@@ -195,7 +196,15 @@ MODEL_ANCHORS = {m: m.__name__ for m in ALL_MODELS}
 
 
 def _anchor(name: str) -> str:
-    return name.lower().replace(" ", "-").replace("_", "-").replace(":", "").replace("(", "").replace(")", "").replace(".", "")
+    return (
+        name.lower()
+        .replace(" ", "-")
+        .replace("_", "-")
+        .replace(":", "")
+        .replace("(", "")
+        .replace(")", "")
+        .replace(".", "")
+    )
 
 
 def _strip_annotated(annotation: Any) -> Any:
@@ -208,7 +217,10 @@ def _render_type(annotation: Any) -> str:
     annotation = _strip_annotated(annotation)
     origin = get_origin(annotation)
 
-    if origin is Union:
+    # Both spellings of a union reach here: typing.Union[...] (origin is
+    # typing.Union) and the PEP 604 `X | Y` form (origin is types.UnionType).
+    # They must render identically -- models.py uses the `|` form.
+    if origin is Union or origin is types.UnionType:
         args = [a for a in get_args(annotation) if a is not type(None)]
         rendered = [_render_type(a) for a in args]
         return " or ".join(dict.fromkeys(rendered))  # dedupe, preserve order
@@ -217,11 +229,11 @@ def _render_type(annotation: Any) -> str:
         values = get_args(annotation)
         return " | ".join(f'"{v}"' for v in values)
 
-    if origin in (list, List):
+    if origin in (list, list):
         (item,) = get_args(annotation)
         return f"list of {_render_type(item)}"
 
-    if origin in (dict, Dict):
+    if origin in (dict, dict):
         return "map"
 
     if isinstance(annotation, type) and issubclass(annotation, BaseModel):
@@ -261,12 +273,19 @@ def _render_default(field: FieldInfo) -> str:
 # fields first instead, with common ones broken out into their own rows below
 # a divider so a kind's *distinctive* shape is what a reader sees first.
 _COMMON_ASPECT_FIELD_ORDER = [
-    "owners", "tags", "glossaryTerms", "domains", "applications",
-    "links", "deprecation", "structuredProperties", "subTypes",
+    "owners",
+    "tags",
+    "glossaryTerms",
+    "domains",
+    "applications",
+    "links",
+    "deprecation",
+    "structuredProperties",
+    "subTypes",
 ]
 
 
-def _render_field_row(model: Type[BaseModel], py_name: str, field: FieldInfo) -> str:
+def _render_field_row(model: type[BaseModel], py_name: str, field: FieldInfo) -> str:
     yaml_name = field.alias or py_name
     required = "**yes**" if field.is_required() else "no"
     type_str = _render_type(field.annotation)
@@ -275,8 +294,11 @@ def _render_field_row(model: Type[BaseModel], py_name: str, field: FieldInfo) ->
     return f"| `{yaml_name}` | {type_str} | {required} | {default} | {description} |"
 
 
-def _render_field_table(model: Type[BaseModel]) -> str:
-    header = ["| Field | Type | Required | Default | Description |", "| --- | --- | --- | --- | --- |"]
+def _render_field_table(model: type[BaseModel]) -> str:
+    header = [
+        "| Field | Type | Required | Default | Description |",
+        "| --- | --- | --- | --- | --- |",
+    ]
     all_fields = model.model_fields
     common_present = [name for name in _COMMON_ASPECT_FIELD_ORDER if name in all_fields]
     own_fields = [name for name in all_fields if name not in _COMMON_ASPECT_FIELD_ORDER]
@@ -299,15 +321,17 @@ def _render_field_table(model: Type[BaseModel]) -> str:
     return "\n".join(lines)
 
 
-def _model_doc(model: Type[BaseModel]) -> str:
+def _model_doc(model: type[BaseModel]) -> str:
     if model.__doc__:
         return " ".join(line.strip() for line in model.__doc__.strip().splitlines())
     return ""
 
 
 def build_markdown() -> str:
-    lines: List[str] = []
-    lines.append("<!-- AUTO-GENERATED by scripts/generate_markdown_docs.py -- do not edit by hand. -->")
+    lines: list[str] = []
+    lines.append(
+        "<!-- AUTO-GENERATED by scripts/generate_markdown_docs.py -- do not edit by hand. -->"
+    )
     lines.append("# YAML Metadata Format Reference")
     lines.append("")
     lines.append(

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,12 @@ setup(
             "jsonschema>=4.0.0",
             "GitPython>=3.1.37,<4",
             "boto3>=1.35.0,<2",
+            # Lint/format and type-check, run by .github/workflows/quality.yml
+            # (see spec/spec-process-cicd-quality.md). Ruff is capped to a
+            # minor because its lint rules shift between minors; local and CI
+            # must agree on the exact ruleset.
+            "ruff>=0.12,<0.13",
+            "mypy>=1.17",
         ],
     },
     entry_points={

--- a/spec/spec-process-cicd-ci.md
+++ b/spec/spec-process-cicd-ci.md
@@ -1,0 +1,252 @@
+---
+title: CI/CD Workflow Specification - CI
+version: 1.1
+date_created: 2026-08-16
+last_updated: 2026-08-16
+owner: David Ouagne
+tags: [process, cicd, github-actions, automation, python, datahub, pytest]
+---
+
+## Workflow Overview
+
+**Purpose**: Verify, on every push and pull request, that the `datahub-yaml-source` plugin installs, its
+`yaml` ingestion source registers, its full test suite passes across supported Python versions, and its
+derived documentation/schema artifacts remain in sync with the Pydantic models they are generated from.
+
+**Trigger Events**: Push to `main`; pull request targeting `main`; manual dispatch.
+
+**Target Environments**: None (library/plugin package; no deployment target). CI-only, no release/publish
+stage.
+
+> **Status**: Implemented at `.github/workflows/ci.yml`. This document is the design contract that file
+> must satisfy; changes to either should keep the other in sync, per Change Management below.
+
+## Execution Flow Diagram
+
+```mermaid
+graph TD
+    A[Trigger: push / PR to main / manual] --> B[test: matrix py3.10-3.12]
+    A --> C[minimal-install-check]
+    B --> D[ci-status]
+    C --> D[ci-status]
+
+    style A fill:#e1f5fe
+    style D fill:#e8f5e8
+```
+
+## Jobs & Dependencies
+
+| Job Name | Purpose | Dependencies | Execution Context |
+|----------|---------|--------------|-------------------|
+| `test` | Install with dev extras; run unit + integration tests with coverage across the supported Python matrix. Transitively verifies generated-artifact freshness and golden-file stability (see REQ-002, REQ-003). | None | Linux runner, matrix over Python 3.10–3.12 |
+| `minimal-install-check` | Install with base dependencies only (no optional extras); confirm the package imports and the `yaml` source plugin registers. | None | Linux runner, single Python version |
+| `ci-status` | Aggregate gate: succeeds only if `test` (all matrix legs) and `minimal-install-check` succeed. Gives branch protection one stable required-check name. | `test`, `minimal-install-check` | Linux runner, no build steps |
+
+## Requirements Matrix
+
+### Functional Requirements
+
+| ID | Requirement | Priority | Acceptance Criteria |
+|----|-------------|----------|---------------------|
+| REQ-001 | Install the package with its development extra on every supported Python version. | High | Install command completes with exit code 0 on each matrix leg. |
+| REQ-002 | Run the full test suite (unit + integration). | High | All tests pass; suite includes tests that fail if generated docs/schema (`docs/sources/yaml/reference.md`, `docs/sources/yaml/schema/yaml-metadata.schema.json`) are stale relative to the Pydantic models in `models.py`. |
+| REQ-003 | Verify the golden-file integration fixture is stable. | High | The golden-file comparison test passes without invoking any golden-file *update* mode. |
+| REQ-004 | Enforce the documented coverage bar. | Medium | Coverage run reports ≥80% overall; build fails below threshold. |
+| REQ-005 | Verify the package installs and its ingestion source registers using only mandatory (non-extra) dependencies. | High | A base-only install followed by a plugin-registration check confirms the `yaml` source is discoverable, without installing the `git` or `s3` extras. |
+| REQ-006 | Run on a platform where the golden-file comparison exercises its primary (non-degraded) code path. | High | Primary execution environment is Linux. |
+| REQ-007 | Aggregate all required checks under one named gate for branch protection. | Medium | A single job depends on every other required job and fails if any of them fails or is skipped. |
+
+### Security Requirements
+
+| ID | Requirement | Implementation Constraint |
+|----|-------------|---------------------------|
+| SEC-001 | Grant the workflow no more repository access than reading source. | Token permissions scoped to read-only contents; no write, no packages, no deployments scope. |
+| SEC-002 | Require no secrets. | The workflow must not reference any repository or organization secret — the test suite is fully hermetic (no live DataHub instance, no cloud credentials, no registry credentials). |
+| SEC-003 | Never let CI mutate golden/reference artifacts and treat that as passing. | The golden-file *update* mode must never be invoked in this workflow; only the read/compare mode runs. |
+
+### Performance Requirements
+
+| ID | Metric | Target | Measurement Method |
+|----|-------|--------|---------------------|
+| PERF-001 | Wall-clock time for the `test` job (single matrix leg) | Under 5 minutes | Time from checkout to job completion, excluding queue wait |
+| PERF-002 | Superseded runs on the same ref are not left running | Redundant runs cancelled | New push to the same PR/branch cancels the previous in-flight run for that ref |
+| PERF-003 | Dependency installation reuses cached wheels between runs when the dependency set is unchanged | Cache hit on unchanged `setup.py` | Install step reports a cache hit when `setup.py` is unchanged since the last run |
+
+## Input/Output Contracts
+
+### Inputs
+
+```yaml
+# Repository Triggers
+paths: []          # no path filters; every push/PR is evaluated
+branches: [main]   # push trigger scope
+# Pull requests targeting `main` also trigger, regardless of source branch
+
+# Environment Variables
+# None required.
+
+# Secrets
+# None required.
+```
+
+### Outputs
+
+```yaml
+# Job Outputs
+test_result: status            # Description: pass/fail per Python-version matrix leg
+minimal_install_result: status # Description: pass/fail of the base-dependency install/registration check
+ci_status: status               # Description: aggregate pass/fail consumed by branch protection
+coverage_report: text           # Description: per-module coverage summary emitted to job logs
+```
+
+### Secrets & Variables
+
+| Type | Name | Purpose | Scope |
+|------|------|---------|-------|
+| — | — | None required | — |
+
+## Execution Constraints
+
+### Runtime Constraints
+
+- **Timeout**: Each job bounded to a fixed maximum (recommend 10 minutes) to fail fast on hangs rather than
+  consuming runner time indefinitely.
+- **Concurrency**: One in-flight run per ref; a new push cancels the previous run for the same ref (PERF-002).
+- **Resource Limits**: Standard hosted Linux runner; no elevated compute required (no compilation of native
+  extensions beyond what `pip install` resolves from wheels).
+
+### Environmental Constraints
+
+- **Runner Requirements**: Linux (REQ-006). No Windows runner in the required path — Windows is excluded
+  because the golden-file comparison falls back to a weaker structural check there (see Edge Cases).
+- **Network Access**: Outbound access to the Python package index only, for dependency installation. No
+  access to any DataHub instance, cloud storage, or git server is required — all such interactions in the
+  test suite are simulated with in-process fakes.
+- **Permissions**: Read-only repository contents (SEC-001).
+
+## Error Handling Strategy
+
+| Error Type | Response | Recovery Action |
+|------------|----------|------------------|
+| Dependency install failure | Fail the affected job immediately | Investigate dependency resolution (e.g. an incompatible `acryl-datahub` release); pin or adjust `setup.py` |
+| Unit/integration test failure | Fail the `test` job for that matrix leg | Fix the failing code or test; re-run |
+| Generated-artifact drift (docs/schema out of sync with models) | Fail via the dedicated drift-detection tests inside the `test` job | Regenerate `docs/sources/yaml/reference.md` and `docs/sources/yaml/schema/yaml-metadata.schema.json` from the current models and commit them alongside the model change |
+| Golden-file mismatch | Fail via the golden-file comparison test | Review whether the output change is intentional; if so, regenerate the golden file locally and review the diff by hand before committing — never regenerate inside CI |
+| Coverage below threshold | Fail the `test` job | Add tests for the newly uncovered lines, or justify and adjust the threshold deliberately |
+| Minimal-install / plugin-registration failure | Fail `minimal-install-check` | Audit for a module-level import of an optional-extra dependency (`GitPython`, `boto3`) that should be lazy |
+| Any required job failure | `ci-status` fails | Branch protection blocks merge until resolved |
+
+## Quality Gates
+
+### Gate Definitions
+
+| Gate | Criteria | Bypass Conditions |
+|------|----------|---------------------|
+| Test suite | All unit and integration tests pass on every matrix leg | None |
+| Coverage threshold | Overall coverage ≥80% | None; threshold change requires updating this specification |
+| Generated-artifact freshness | Docs/schema match current model definitions | None |
+| Golden-file stability | Integration fixture output matches the committed golden file | None — intentional changes require a reviewed, hand-committed golden-file update, not a bypass |
+| Minimal-install integrity | Package imports and plugin registers using only mandatory dependencies | None |
+
+## Monitoring & Observability
+
+### Key Metrics
+
+- **Success Rate**: Track `ci-status` pass rate on `main` over time; a healthy `main` should stay green.
+- **Execution Time**: Track `test` job duration per matrix leg against PERF-001.
+- **Resource Usage**: Not tracked beyond standard hosted-runner minutes consumption.
+
+### Alerting
+
+| Condition | Severity | Notification Target |
+|-----------|----------|----------------------|
+| `ci-status` fails on `main` (post-merge) | High | Repository maintainer(s) via default GitHub notification on the failing commit |
+| Repeated flakiness in the `test` job across unrelated PRs | Medium | Repository maintainer(s), for investigation as a suite reliability issue |
+
+## Integration Points
+
+### External Systems
+
+| System | Integration Type | Data Exchange | SLA Requirements |
+|--------|-------------------|----------------|-------------------|
+| Python Package Index | Dependency resolution | Package downloads at install time | Best-effort; no SLA — treated as a build-time dependency, not a runtime one |
+
+No DataHub instance, cloud storage service, or external git host is contacted during this workflow: the
+loader's git/S3/HTTP code paths are exercised in the test suite exclusively through in-process fakes.
+
+### Dependent Workflows
+
+| Workflow | Relationship | Trigger Mechanism |
+|----------|---------------|---------------------|
+| Release/publish (not yet specified) | Downstream, out of scope for this spec | Would depend on `ci-status` succeeding on `main`, if introduced |
+
+## Compliance & Governance
+
+### Audit Requirements
+
+- **Execution Logs**: Retained per the hosting platform's default workflow-run retention; no custom
+  retention policy required given the absence of secrets or sensitive data in logs.
+- **Approval Gates**: None beyond standard pull-request review; this workflow provides the automated check
+  that review can rely on.
+- **Change Control**: Changes to gates described here (test scope, coverage threshold, Python matrix) must
+  update this specification first, per the Change Management section below.
+
+### Security Controls
+
+- **Access Control**: Read-only `contents` permission (SEC-001); no write-scoped tokens.
+- **Secret Management**: Not applicable — no secrets are used (SEC-002).
+- **Vulnerability Scanning**: Not currently in scope for this workflow; dependency vulnerability scanning is
+  a candidate future addition, not a current requirement.
+
+## Edge Cases & Exceptions
+
+### Scenario Matrix
+
+| Scenario | Expected Behavior | Validation Method |
+|----------|---------------------|------------------------|
+| Run on a Windows runner | Not part of the required path. If run experimentally, the golden-file comparison degrades to a weaker structural check (a known limitation of the file sink's path handling on Windows), so a Windows leg must never be treated as equivalent evidence to the Linux leg. | Manual code inspection of the golden-file test's platform-conditional fallback; do not add Windows as a required check without addressing this. |
+| PR modifies `models.py` without regenerating docs/schema | `test` job fails via the drift-detection tests | Confirmed by design: dedicated tests compare committed artifacts against freshly generated output |
+| PR modifies `models.py` and regenerates docs/schema correctly | `test` job passes | Standard test run |
+| Optional extra (`git`, `s3`) dependency accidentally imported at module level in core code | `minimal-install-check` fails at import time | Confirmed empirically: a base-only install (no extras) imports the plugin entry point successfully today |
+| Contributor runs `--update-golden-files` locally and commits an unintended change | Not caught by this workflow directly — CI compares against whatever golden file is committed | Relies on human review of the golden-file diff, as instructed in `CONTRIBUTING.md` |
+| Dependency floor (`acryl-datahub>=1.7.0`) resolves a newer release that drops a transitive dependency the code relies on (`requests`, `pydantic`) | Install or import may fail unpredictably | Not currently guarded by a pinned upper bound; a floating risk noted for future hardening, not fixed by this workflow alone |
+
+## Validation Criteria
+
+### Workflow Validation
+
+- **VLD-001**: `test` job passes on all matrix legs (Python 3.10, 3.11, 3.12) using `pip install -e ".[dev]"`.
+- **VLD-002**: `minimal-install-check` passes using a base install (`pip install .`, no extras) and confirms
+  the `yaml` source is listed among registered ingestion source plugins.
+- **VLD-003**: `ci-status` reports failure if either `test` or `minimal-install-check` fails, and success
+  only when both succeed.
+- **VLD-004**: No job in this workflow invokes any golden-file *update* mode.
+- **VLD-005**: No job in this workflow references a secret.
+
+### Performance Benchmarks
+
+- **PERF-001** (restated): Single `test` matrix leg completes in under 5 minutes.
+- **PERF-004**: Total workflow wall-clock time (slowest path, including matrix parallelism) stays under 10
+  minutes under normal runner availability.
+
+## Change Management
+
+### Update Process
+
+1. **Specification Update**: Modify this document first.
+2. **Review & Approval**: Standard pull-request review of the specification change.
+3. **Implementation**: Apply changes to `.github/workflows/ci.yml`.
+4. **Testing**: Confirm the updated workflow satisfies the Validation Criteria above on a trial PR.
+5. **Deployment**: Merge once the trial run demonstrates conformance.
+
+### Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-08-16 | Initial specification, written against a repository with no existing CI workflow | David Ouagne |
+| 1.1 | 2026-08-16 | Corrected the Python matrix from 3.9–3.12 to 3.10–3.12: `acryl-datahub>=1.7.0`, a mandatory dependency, itself requires Python >=3.10 (confirmed via its PyPI classifiers), so a 3.9 leg was unsatisfiable. Marked the workflow as implemented at `.github/workflows/ci.yml`. | David Ouagne |
+
+## Related Specifications
+
+- None yet. A future release/publish workflow specification, if introduced, should reference this document
+  as its upstream gate.

--- a/spec/spec-process-cicd-quality.md
+++ b/spec/spec-process-cicd-quality.md
@@ -1,0 +1,202 @@
+---
+title: CI/CD Workflow Specification - Code Quality (Ruff + mypy)
+version: 1.0
+date_created: 2026-09-05
+last_updated: 2026-09-05
+owner: David Ouagne
+tags: [process, cicd, github-actions, automation, python, lint, format, typing, ruff, mypy]
+---
+
+## Workflow Overview
+
+**Purpose**: On every push and pull request, enforce a single lint + format standard for all
+first-party Python (`src/`, `tests/`, `scripts/`) via Ruff, and surface (without gating) static
+type-checking findings from mypy over the package source. Complements `spec/spec-process-cicd-ci.md`,
+which owns install/test/coverage; this workflow owns style and typing only.
+
+**Trigger Events**: Push to `main`; pull request targeting `main`; manual dispatch.
+
+**Target Environments**: None (library/plugin package). CI-only.
+
+> **Status**: Implemented at `.github/workflows/quality.yml`. This document is the design contract
+> that file must satisfy; changes to either should keep the other in sync, per Change Management below.
+
+## Execution Flow Diagram
+
+```mermaid
+graph TD
+    A[Trigger: push / PR to main / manual] --> B[ruff: check + format --check]
+    A --> C["mypy (advisory, continue-on-error)"]
+
+    style A fill:#e1f5fe
+    style B fill:#e8f5e8
+    style C fill:#fff3e0
+```
+
+## Jobs & Dependencies
+
+| Job Name | Purpose | Blocking? | Dependencies | Execution Context |
+|----------|---------|-----------|--------------|-------------------|
+| `ruff` | `ruff check` (lint) + `ruff format --check` (format) over the repo. Its job name is the stable required-check string for branch protection on `main`. | Yes | None | Linux runner, Python 3.12 |
+| `mypy (advisory)` | Run mypy over `src/` using the `[tool.mypy]` config in `pyproject.toml`. Reports findings in the run log; never fails the workflow (`continue-on-error: true`). | No | None | Linux runner, Python 3.12 |
+
+## Requirements Matrix
+
+### Functional Requirements
+
+| ID | Requirement | Priority | Acceptance Criteria |
+|----|-------------|----------|---------------------|
+| REQ-001 | Lint all first-party Python with Ruff. | High | `ruff check .` exits 0; any violation fails the `ruff` job. |
+| REQ-002 | Enforce a single auto-format. | High | `ruff format --check .` reports no file would be reformatted. |
+| REQ-003 | Lint/format config is version-controlled and single-source. | High | `[tool.ruff]` lives in `pyproject.toml`; no competing `ruff.toml`/`setup.cfg` lint config exists. |
+| REQ-004 | Tool versions match between CI and a local `pip install -e ".[dev]"`. | Medium | `ruff` and `mypy` are pinned in `setup.py`'s `dev` extra; the workflow installs only that extra, no ad-hoc tool install. |
+| REQ-005 | Run mypy over the package source and surface its output. | Medium | `mypy` runs against `files = ["src"]`; findings appear in the job log. |
+| REQ-006 | mypy never blocks merge (for now). | High | The `mypy` job is `continue-on-error: true`; a non-zero mypy exit does not fail the workflow or any required check. |
+| REQ-007 | The blocking check has one stable name for branch protection. | High | The blocking job is named exactly `ruff`; renaming it is a breaking change requiring a branch-protection update (see `spec/spec-process-cicd-ci.md` REQ-007 for the analogous `ci-status`). |
+
+### Security Requirements
+
+| ID | Requirement | Implementation Constraint |
+|----|-------------|---------------------------|
+| SEC-001 | No more repo access than reading source. | `permissions: contents: read`; no write/packages/deployments scope. |
+| SEC-002 | No secrets. | The workflow references no repository or organization secret. |
+
+### Performance Requirements
+
+| ID | Metric | Target | Measurement Method |
+|----|-------|--------|---------------------|
+| PERF-001 | Wall-clock for the `ruff` job | Under 3 minutes | Checkout to job completion, excluding queue wait. |
+| PERF-002 | Superseded runs on the same ref are cancelled | Redundant runs cancelled | `concurrency` group with `cancel-in-progress: true`. |
+| PERF-003 | Dependency install reuses cached wheels when `setup.py` is unchanged | Cache hit reported | `actions/setup-python` pip cache keyed on `setup.py`. |
+
+## Input/Output Contracts
+
+### Inputs
+
+```yaml
+branches: [main]     # push trigger scope
+# Pull requests targeting `main` also trigger, regardless of source branch.
+# Environment Variables: none required.
+# Secrets: none required.
+```
+
+### Outputs
+
+```yaml
+ruff_result: status   # pass/fail of lint + format-check; consumed by branch protection
+mypy_result: status   # advisory; surfaced in logs, not consumed as a gate
+```
+
+## Execution Constraints
+
+- **Timeout**: Each job bounded to 10 minutes.
+- **Concurrency**: One in-flight run per ref (`quality-${{ github.workflow }}-${{ github.ref }}`).
+- **Runner**: Standard hosted Linux runner. Single Python version (3.12) — lint and format results are
+  not Python-version-sensitive at the project's `target-version` (`py310`), so no matrix.
+- **Network**: Outbound to the Python package index only, for dependency installation.
+- **Permissions**: Read-only `contents` (SEC-001).
+
+## Tooling Configuration (authoritative pointers)
+
+The exact configuration lives in `pyproject.toml`; this section records the decisions and their rationale.
+
+### Ruff
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| `line-length` | `100` | A deliberate loosening from the 88 default; the pre-existing code sat well above 88 and 100 keeps the one-off reformat from rewrapping nearly every signature. |
+| `target-version` | `py310` | Matches `setup.py`'s `python_requires` floor (driven by `acryl-datahub>=1.7.0`). |
+| `lint.select` | `E`, `F`, `I`, `UP`, `B`, `C4`, `SIM`, `RUF` | pycodestyle/pyflakes errors, import sorting, pyupgrade, bugbear, comprehensions, simplify, Ruff-native. Deliberately excludes `ANN` (annotation completeness — that is mypy's job, advisory) and `PL` (too opinionated for a solo maintainer). |
+| `lint.per-file-ignores` | `__init__.py` → `F401`; `tests/**` → `E501` | Re-export modules use unused imports on purpose; test fixtures embed full DataHub URNs and JSON blobs as string literals that are not meaningfully breakable. The formatter still enforces 100 cols on everything it can reflow. |
+| `lint.isort.known-first-party` | `["datahub_yaml_source"]` | Correct first/third-party split in a `src/` layout. |
+
+Two `# noqa: E501` are carried in `src/datahub_yaml_source/models.py`: one on an aligned ASCII
+capability matrix in a comment block (reflowing destroys the alignment) and one on a single-line class
+docstring whose text is consumed verbatim by `scripts/generate_json_schema.py` (splitting it would
+inject `\n` into the emitted JSON Schema).
+
+**Generator coupling**: `scripts/generate_markdown_docs.py` renders the type column of
+`docs/sources/yaml/reference.md` from the Pydantic field annotations in `models.py`. Ruff's `UP`
+rules rewrote `Optional[X]`/`List[X]` to `X | None`/`list[X]`; `_render_type` was updated to treat
+`types.UnionType` identically to `typing.Union` so the generated docs are byte-identical before and
+after the reformat. Any future change to the `UP` rule set must be followed by regenerating the
+schema + docs (per `AGENTS.md`) and confirming no drift.
+
+### mypy
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| `files` | `["src"]` | Package source only. `tests/` and `scripts/` are out of scope until the `src/` signal is clean. |
+| `python_version` | `"3.10"` | Assume the semantics of the supported floor. |
+| `check_untyped_defs` | `true` | Type-check bodies of unannotated functions — most of the value on a codebase with sparse annotations. |
+| `warn_unused_ignores`, `warn_redundant_casts` | `true` | Low-noise staleness detectors. |
+| overrides: `datahub.*`, `deepdiff.*` | `ignore_missing_imports = true` | `acryl-datahub` ships partial/absent type information; without this the log is dominated by import errors rather than findings about our code. |
+| `strict` | *not set* | Advisory job; a strict baseline would be noise, not signal. Tightening toward strict is tracked as fog on the wayfinder map. |
+
+### Known mypy baseline
+
+At v1.0 of this spec, `mypy` reports **31 errors across 11 files** (chiefly `arg-type` mismatches
+where our models pass `list[str]` / `str | None` into `acryl-datahub` SDK constructors that expect
+`list[str | SomeUrn]` / `str`). This is recorded, not suppressed: the job is advisory precisely so
+this baseline is visible and can be driven down before mypy is promoted to blocking. There is no
+mypy baseline/ignore file and no `# type: ignore` sweep.
+
+## Error Handling Strategy
+
+| Error Type | Response | Recovery Action |
+|------------|----------|------------------|
+| Lint violation | Fail the `ruff` job | Run `ruff check --fix .` locally; hand-fix what `--fix` won't. |
+| Formatting difference | Fail the `ruff` job | Run `ruff format .` locally and commit. |
+| mypy error(s) | Logged; job still succeeds (`continue-on-error`) | Address opportunistically; drives the baseline in this spec down over time. |
+| Dependency install failure | Fail the affected job | Investigate resolution against `setup.py`. |
+
+## Quality Gates
+
+| Gate | Criteria | Bypass Conditions |
+|------|----------|---------------------|
+| Lint | `ruff check .` clean | None; rule-set changes require updating this spec. |
+| Format | `ruff format --check .` clean | None. |
+| Types | mypy run completes and output is captured | Never a gate at this spec version; promotion requires a spec update. |
+
+## Integration Points
+
+### Dependent Workflows
+
+| Workflow | Relationship | Trigger Mechanism |
+|----------|---------------|---------------------|
+| Branch protection on `main` | Consumes the `ruff` check as a required status check | GitHub branch protection API (see the branch-protection ticket on wayfinder map issue #1) |
+| `spec/spec-process-cicd-ci.md` (CI) | Sibling; disjoint responsibility (install/test/coverage). Both gate `main`. | Same trigger events |
+
+## Validation Criteria
+
+- **VLD-001**: On a branch with a deliberate lint violation, the `ruff` job fails.
+- **VLD-002**: On a branch with an unformatted file, the `ruff` job fails with a diff in the log.
+- **VLD-003**: On a branch that adds a new mypy error, the workflow still concludes successfully and
+  the `mypy (advisory)` job shows the error in its log.
+- **VLD-004**: No job in this workflow references a secret.
+- **VLD-005**: `pip install -e ".[dev]"` on a clean checkout provides `ruff` and `mypy` at the
+  versions the workflow runs.
+
+## Change Management
+
+### Update Process
+
+1. **Specification Update**: Modify this document first.
+2. **Review & Approval**: Standard pull-request review.
+3. **Implementation**: Apply changes to `.github/workflows/quality.yml` and/or `pyproject.toml` /
+   `setup.py`.
+4. **Testing**: Confirm the Validation Criteria on a trial PR.
+5. **Deployment**: Merge once the trial run conforms.
+
+Renaming the `ruff` job, or promoting `mypy` to blocking, additionally requires updating the branch
+protection configuration for `main`.
+
+### Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-09-05 | Initial specification. Ruff (blocking: `check` + `format --check`) and mypy (advisory, `continue-on-error`) added as `.github/workflows/quality.yml`; `[tool.ruff]` / `[tool.mypy]` introduced in a new `pyproject.toml`; `ruff`/`mypy` pinned in `setup.py`'s `dev` extra. One-off `ruff format` + safe `ruff check --fix` applied across `src/`, `tests/`, `scripts/`. Recorded mypy baseline: 31 errors / 11 files. | David Ouagne |
+
+## Related Specifications
+
+- `spec/spec-process-cicd-ci.md` — CI (install, test, coverage). This workflow is its style/typing sibling; both are required checks on `main` (the `mypy` job excepted).

--- a/src/datahub_yaml_source/builders/application.py
+++ b/src/datahub_yaml_source/builders/application.py
@@ -1,7 +1,11 @@
-from typing import Iterable, List, Optional
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.metadata.schema_classes import ApplicationLineageClass, ApplicationPropertiesClass, EdgeClass
+from datahub.metadata.schema_classes import (
+    ApplicationLineageClass,
+    ApplicationPropertiesClass,
+    EdgeClass,
+)
 
 from datahub_yaml_source.builders.common import common_aspect_mcps, mcp_workunit
 from datahub_yaml_source.models import ApplicationDoc, ApplicationLineageEdgeDoc
@@ -10,15 +14,16 @@ from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
 
 def _application_lineage_edges(
-    edges: Optional[List[ApplicationLineageEdgeDoc]], direction: str, context: str
-) -> Optional[List[EdgeClass]]:
+    edges: list[ApplicationLineageEdgeDoc] | None, direction: str, context: str
+) -> list[EdgeClass] | None:
     if not edges:
         return None
     result = []
     for i, edge in enumerate(edges):
         if bool(edge.api) == bool(edge.dataset):
             raise ValueError(
-                f"{context} applicationLineage.{direction}[{i}] must set exactly one of 'api' or 'dataset'"
+                f"{context} applicationLineage.{direction}[{i}] must set "
+                f"exactly one of 'api' or 'dataset'"
             )
         destination_urn = api_urn(edge.api) if edge.api else dataset_urn(edge.dataset)
         result.append(EdgeClass(destinationUrn=destination_urn))
@@ -38,8 +43,12 @@ def build_application(
     # `build_document`'s equivalent native/external check for the same reason).
     input_edges = output_edges = None
     if doc.applicationLineage:
-        input_edges = _application_lineage_edges(doc.applicationLineage.consumes, "consumes", context)
-        output_edges = _application_lineage_edges(doc.applicationLineage.produces, "produces", context)
+        input_edges = _application_lineage_edges(
+            doc.applicationLineage.consumes, "consumes", context
+        )
+        output_edges = _application_lineage_edges(
+            doc.applicationLineage.produces, "produces", context
+        )
 
     yield mcp_workunit(
         entity_urn,

--- a/src/datahub_yaml_source/builders/assertion.py
+++ b/src/datahub_yaml_source/builders/assertion.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
@@ -123,7 +123,9 @@ def _build_volume_assertion(doc: AssertionDoc) -> VolumeAssertionInfoClass:
     # required in the Avro schema despite the generated stub typing them
     # Optional -- passing None parses fine but fails MCP validation at emit
     # time (same trap as `DeprecationClass.note`, see build_deprecation_aspect()).
-    parameters = AssertionStdParametersClass(value=AssertionStdParameterClass(value=str(a.value), type="NUMBER"))
+    parameters = AssertionStdParametersClass(
+        value=AssertionStdParameterClass(value=str(a.value), type="NUMBER")
+    )
     if a.volumeType == "ROW_COUNT_CHANGE":
         return VolumeAssertionInfoClass(
             type="ROW_COUNT_CHANGE",
@@ -161,13 +163,17 @@ def _build_data_schema_assertion(doc: AssertionDoc) -> SchemaAssertionInfoClass:
         platformSchema=OtherSchemaClass(rawSchema=""),
         fields=fields,
     )
-    return SchemaAssertionInfoClass(entity=a.entityUrn, schema=expected_schema, compatibility=a.compatibility)
+    return SchemaAssertionInfoClass(
+        entity=a.entityUrn, schema=expected_schema, compatibility=a.compatibility
+    )
 
 
 def _build_custom_assertion(doc: AssertionDoc) -> CustomAssertionInfoClass:
     a = doc.assertion
     field_spec = (
-        SchemaFieldSpecClass(path=a.fieldPath, type=a.dataType or "string", nativeType=a.nativeDataType or "")
+        SchemaFieldSpecClass(
+            path=a.fieldPath, type=a.dataType or "string", nativeType=a.nativeDataType or ""
+        )
         if a.fieldPath
         else None
     )
@@ -186,7 +192,7 @@ _BUILDERS = {
 }
 
 
-def _build_assertion_actions(actions: Optional[AssertionActionsDoc]) -> Optional[AssertionActionsClass]:
+def _build_assertion_actions(actions: AssertionActionsDoc | None) -> AssertionActionsClass | None:
     if actions is None:
         return None
     return AssertionActionsClass(
@@ -212,7 +218,14 @@ def build_assertion(
     custom_properties = None
     if doc.properties:
         custom_properties = stringify_custom_properties(
-            {k: v for k, v in {"name": doc.properties.name, "dbt_test": doc.properties.dbt_test}.items() if v is not None}
+            {
+                k: v
+                for k, v in {
+                    "name": doc.properties.name,
+                    "dbt_test": doc.properties.dbt_test,
+                }.items()
+                if v is not None
+            }
         )
 
     aspect = AssertionInfoClass(

--- a/src/datahub_yaml_source/builders/chart.py
+++ b/src/datahub_yaml_source/builders/chart.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.sdk.chart import Chart

--- a/src/datahub_yaml_source/builders/common.py
+++ b/src/datahub_yaml_source/builders/common.py
@@ -1,12 +1,14 @@
 """Shared helpers used across builders/*.py."""
 
-from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Tuple, Union
+from collections.abc import Iterable
+from typing import Any
 
 from datahub.emitter.mce_builder import make_schema_field_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     ApplicationsClass,
+    AuditStampClass,
     BooleanTypeClass,
     BytesTypeClass,
     DataPlatformInstanceClass,
@@ -34,7 +36,6 @@ from datahub.metadata.schema_classes import (
     TagAssociationClass,
     TimeTypeClass,
 )
-from datahub.metadata.schema_classes import AuditStampClass
 
 from datahub_yaml_source.models import (
     DeprecationDoc,
@@ -84,12 +85,12 @@ def schema_field_data_type(source_type: str) -> SchemaFieldDataTypeClass:
     return SchemaFieldDataTypeClass(type=type_cls())
 
 
-def owners_to_sdk_input(owners: List[OwnerEntry]) -> List[Tuple[str, str]]:
+def owners_to_sdk_input(owners: list[OwnerEntry]) -> list[tuple[str, str]]:
     """Owner input for SDK V2 entities: list of (owner_urn, ownership_type) tuples."""
     return [(owner_urn(o.owner), o.type) for o in owners]
 
 
-def build_ownership_aspect(owners: List[OwnerEntry]) -> Optional[OwnershipClass]:
+def build_ownership_aspect(owners: list[OwnerEntry]) -> OwnershipClass | None:
     """Ownership aspect for kinds without SDK V2 support (raw MCP emission)."""
     if not owners:
         return None
@@ -98,32 +99,30 @@ def build_ownership_aspect(owners: List[OwnerEntry]) -> Optional[OwnershipClass]
     )
 
 
-def build_global_tags_aspect(tag_names: Optional[List[str]]) -> Optional[GlobalTagsClass]:
+def build_global_tags_aspect(tag_names: list[str] | None) -> GlobalTagsClass | None:
     if not tag_names:
         return None
     return GlobalTagsClass(tags=[TagAssociationClass(tag=tag_urn(t)) for t in tag_names])
 
 
 def build_glossary_terms_aspect(
-    term_ids: Optional[List[str]],
-) -> Optional[GlossaryTermsClass]:
+    term_ids: list[str] | None,
+) -> GlossaryTermsClass | None:
     if not term_ids:
         return None
     return GlossaryTermsClass(
-        terms=[
-            GlossaryTermAssociationClass(urn=glossary_term_urn(t)) for t in term_ids
-        ],
+        terms=[GlossaryTermAssociationClass(urn=glossary_term_urn(t)) for t in term_ids],
         auditStamp=AuditStampClass(time=0, actor=DEFAULT_ACTOR_URN),
     )
 
 
-def build_domains_aspect(domain_id: Optional[str]) -> Optional[DomainsClass]:
+def build_domains_aspect(domain_id: str | None) -> DomainsClass | None:
     if not domain_id:
         return None
     return DomainsClass(domains=[domain_urn(domain_id)])
 
 
-def stringify_custom_properties(properties: Optional[dict]) -> Optional[dict]:
+def stringify_custom_properties(properties: dict | None) -> dict | None:
     """customProperties aspects require Dict[str, str]; coerce non-str values."""
     if not properties:
         return None
@@ -131,8 +130,8 @@ def stringify_custom_properties(properties: Optional[dict]) -> Optional[dict]:
 
 
 def build_fine_grained_lineage_list(
-    fgl_docs: Optional[List[FineGrainedLineageDoc]],
-) -> Optional[List[FineGrainedLineageClass]]:
+    fgl_docs: list[FineGrainedLineageDoc] | None,
+) -> list[FineGrainedLineageClass] | None:
     if not fgl_docs:
         return None
     return [
@@ -146,7 +145,9 @@ def build_fine_grained_lineage_list(
                 if fg.upstream is not None
                 else []
             ),
-            downstreams=[make_schema_field_urn(dataset_urn(fg.downstream), fg.downstream.fieldPath)],
+            downstreams=[
+                make_schema_field_urn(dataset_urn(fg.downstream), fg.downstream.fieldPath)
+            ],
             transformOperation=fg.operation,
             confidenceScore=fg.confidence,
         )
@@ -167,7 +168,7 @@ def mcp_workunit(entity_urn: str, aspect) -> MetadataWorkUnit:
 # automatically gets whatever the entity registry allows it and nothing else.
 
 
-def build_deprecation_aspect(dep: Optional[DeprecationDoc]) -> Optional[DeprecationClass]:
+def build_deprecation_aspect(dep: DeprecationDoc | None) -> DeprecationClass | None:
     if dep is None:
         return None
     return DeprecationClass(
@@ -190,14 +191,16 @@ def _link_association(link: LinkDoc) -> InstitutionalMemoryMetadataClass:
     )
 
 
-def build_link_associations(links: Optional[List[LinkDoc]]) -> Optional[List[InstitutionalMemoryMetadataClass]]:
+def build_link_associations(
+    links: list[LinkDoc] | None,
+) -> list[InstitutionalMemoryMetadataClass] | None:
     """`links=` input for an SDK V2 constructor -- deterministic (time=0) audit stamp."""
     if not links:
         return None
     return [_link_association(link) for link in links]
 
 
-def build_links_aspect(links: Optional[List[LinkDoc]]) -> Optional[InstitutionalMemoryClass]:
+def build_links_aspect(links: list[LinkDoc] | None) -> InstitutionalMemoryClass | None:
     """Standalone `institutionalMemory` aspect, for raw-MCP kinds and container follow-ups."""
     associations = build_link_associations(links)
     if not associations:
@@ -205,17 +208,17 @@ def build_links_aspect(links: Optional[List[LinkDoc]]) -> Optional[Institutional
     return InstitutionalMemoryClass(elements=associations)
 
 
-def _normalize_structured_property_values(value: Any) -> List[Union[str, float]]:
+def _normalize_structured_property_values(value: Any) -> list[str | float]:
     values = value if isinstance(value, list) else [value]
-    return [v if isinstance(v, (int, float)) else str(v) for v in values]
+    return [v if isinstance(v, int | float) else str(v) for v in values]
 
 
 def build_structured_properties_aspect(
-    properties: Optional[Dict[str, Any]],
+    properties: dict[str, Any] | None,
     index,
     report,
     context: str,
-) -> Optional[StructuredPropertiesClass]:
+) -> StructuredPropertiesClass | None:
     """Always built directly (never via the SDK's `structured_properties=` kwarg,
     nor `gen_containers()`'s `structured_properties=` kwarg): both of those call
     `HasStructuredProperties.set_structured_property()` / a single-value UPSERT
@@ -240,27 +243,29 @@ def build_structured_properties_aspect(
 
 
 def build_applications_aspect(
-    app_ids: Optional[List[str]], index, report, context: str
-) -> Optional[ApplicationsClass]:
+    app_ids: list[str] | None, index, report, context: str
+) -> ApplicationsClass | None:
     if not app_ids:
         return None
     urns = []
     for app_id in app_ids:
         if not index.has_application(app_id):
-            report.report_dangling_reference(f"{context} references undeclared application '{app_id}'")
+            report.report_dangling_reference(
+                f"{context} references undeclared application '{app_id}'"
+            )
         urns.append(application_urn(app_id))
     return ApplicationsClass(applications=urns)
 
 
-def build_subtypes_aspect(sub_types: List[str]) -> Optional[SubTypesClass]:
+def build_subtypes_aspect(sub_types: list[str]) -> SubTypesClass | None:
     if not sub_types:
         return None
     return SubTypesClass(typeNames=sub_types)
 
 
 def build_data_platform_instance_aspect(
-    platform: Optional[str], instance: Optional[str]
-) -> Optional[DataPlatformInstanceClass]:
+    platform: str | None, instance: str | None
+) -> DataPlatformInstanceClass | None:
     """For the software/AI catalog kinds (SERVICE/API/REPOSITORY/AI_AGENT/AGENT_SKILL,
     Phase 5C): their URNs are a bare id with no platform component, so this is the
     only way to say "this repository lives on GitLab" / "this service runs on
@@ -277,12 +282,14 @@ def build_data_platform_instance_aspect(
 
 #: Every SDK V2 entity class in this connector accepts all six as constructor
 #: kwargs (Dataset, DataFlow, DataJob) -- the default for `native=`.
-FULL_NATIVE_KWARGS: FrozenSet[str] = frozenset({"owners", "tags", "terms", "domain", "links", "subtype"})
+FULL_NATIVE_KWARGS: frozenset[str] = frozenset(
+    {"owners", "tags", "terms", "domain", "links", "subtype"}
+)
 
 
 def common_sdk_kwargs(
-    doc, index, report, context: str, *, native: FrozenSet[str] = FULL_NATIVE_KWARGS
-) -> Dict[str, Any]:
+    doc, index, report, context: str, *, native: frozenset[str] = FULL_NATIVE_KWARGS
+) -> dict[str, Any]:
     """Cross-cutting aspect kwargs for an SDK V2-backed kind.
 
     Not every SDK V2 entity wrapper implements the same `Has*` mixins as the
@@ -302,8 +309,8 @@ def common_sdk_kwargs(
     non-deterministic `datetime.now()` audit stamp (see
     `build_structured_properties_aspect()`).
     """
-    kwargs: Dict[str, Any] = {}
-    extra_aspects: List[Any] = []
+    kwargs: dict[str, Any] = {}
+    extra_aspects: list[Any] = []
 
     if isinstance(doc, HasOwners):
         owners = owners_to_sdk_input(normalize_owners(doc.owners)) or None
@@ -316,7 +323,9 @@ def common_sdk_kwargs(
         tags = []
         for tag_name in doc.tags or []:
             if not index.has_tag(tag_name):
-                report.report_dangling_reference(f"{context} references undeclared tag '{tag_name}'")
+                report.report_dangling_reference(
+                    f"{context} references undeclared tag '{tag_name}'"
+                )
             tags.append(tag_urn(tag_name))
         if "tags" in native:
             kwargs["tags"] = tags or None
@@ -327,7 +336,9 @@ def common_sdk_kwargs(
         terms = []
         for term_id in doc.glossaryTerms or []:
             if not index.has_glossary_term(term_id):
-                report.report_dangling_reference(f"{context} references undeclared glossaryTerm '{term_id}'")
+                report.report_dangling_reference(
+                    f"{context} references undeclared glossaryTerm '{term_id}'"
+                )
             terms.append(glossary_term_urn(term_id))
         if "terms" in native:
             kwargs["terms"] = terms or None
@@ -343,7 +354,9 @@ def common_sdk_kwargs(
         domain = None
         if doc.domains:
             if not index.has_domain(doc.domains):
-                report.report_dangling_reference(f"{context} references undeclared domain '{doc.domains}'")
+                report.report_dangling_reference(
+                    f"{context} references undeclared domain '{doc.domains}'"
+                )
             domain = domain_urn(doc.domains)
         if "domain" in native:
             kwargs["domain"] = domain
@@ -379,7 +392,9 @@ def common_sdk_kwargs(
             extra_aspects.append(dep_aspect)
 
     if isinstance(doc, HasStructuredProps):
-        sp_aspect = build_structured_properties_aspect(doc.structuredProperties, index, report, context)
+        sp_aspect = build_structured_properties_aspect(
+            doc.structuredProperties, index, report, context
+        )
         if sp_aspect:
             extra_aspects.append(sp_aspect)
 
@@ -394,7 +409,7 @@ def common_aspect_mcps(
     report,
     context: str,
     *,
-    skip: FrozenSet[str] = frozenset(),
+    skip: frozenset[str] = frozenset(),
 ) -> Iterable[MetadataWorkUnit]:
     """Cross-cutting aspects as standalone follow-up MCPs, for raw-MCP kinds
     (DOMAIN, APPLICATION, DATA_PRODUCT, ASSERTION) and for CONTAINER, which
@@ -409,7 +424,9 @@ def common_aspect_mcps(
     if "tags" not in skip and isinstance(doc, HasTags):
         for tag_name in doc.tags or []:
             if not index.has_tag(tag_name):
-                report.report_dangling_reference(f"{context} references undeclared tag '{tag_name}'")
+                report.report_dangling_reference(
+                    f"{context} references undeclared tag '{tag_name}'"
+                )
         tags_aspect = build_global_tags_aspect(doc.tags)
         if tags_aspect:
             yield mcp_workunit(entity_urn, tags_aspect)
@@ -417,16 +434,19 @@ def common_aspect_mcps(
     if "terms" not in skip and isinstance(doc, HasTerms):
         for term_id in doc.glossaryTerms or []:
             if not index.has_glossary_term(term_id):
-                report.report_dangling_reference(f"{context} references undeclared glossaryTerm '{term_id}'")
+                report.report_dangling_reference(
+                    f"{context} references undeclared glossaryTerm '{term_id}'"
+                )
         terms_aspect = build_glossary_terms_aspect(doc.glossaryTerms)
         if terms_aspect:
             yield mcp_workunit(entity_urn, terms_aspect)
 
-    if "domain" not in skip and isinstance(doc, HasDomain):
-        if doc.domains:
-            if not index.has_domain(doc.domains):
-                report.report_dangling_reference(f"{context} references undeclared domain '{doc.domains}'")
-            yield mcp_workunit(entity_urn, build_domains_aspect(doc.domains))
+    if "domain" not in skip and isinstance(doc, HasDomain) and doc.domains:
+        if not index.has_domain(doc.domains):
+            report.report_dangling_reference(
+                f"{context} references undeclared domain '{doc.domains}'"
+            )
+        yield mcp_workunit(entity_urn, build_domains_aspect(doc.domains))
 
     if "applications" not in skip and isinstance(doc, HasApplications):
         apps_aspect = build_applications_aspect(doc.applications, index, report, context)
@@ -444,7 +464,9 @@ def common_aspect_mcps(
             yield mcp_workunit(entity_urn, dep_aspect)
 
     if "structuredProperties" not in skip and isinstance(doc, HasStructuredProps):
-        sp_aspect = build_structured_properties_aspect(doc.structuredProperties, index, report, context)
+        sp_aspect = build_structured_properties_aspect(
+            doc.structuredProperties, index, report, context
+        )
         if sp_aspect:
             yield mcp_workunit(entity_urn, sp_aspect)
 

--- a/src/datahub_yaml_source/builders/container.py
+++ b/src/datahub_yaml_source/builders/container.py
@@ -1,8 +1,7 @@
 from collections import defaultdict, deque
-from typing import Dict, Iterable, List, Tuple
+from collections.abc import Iterable
 
 from datahub.emitter.mcp_builder import gen_containers
-
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 
 from datahub_yaml_source.builders.common import (
@@ -14,13 +13,18 @@ from datahub_yaml_source.builders.common import (
     stringify_custom_properties,
 )
 from datahub_yaml_source.models import ContainerDoc, normalize_owners, normalize_sub_types
-from datahub_yaml_source.urns import ReferenceIndex, container_key, container_natural_key, domain_urn
+from datahub_yaml_source.urns import (
+    ReferenceIndex,
+    container_key,
+    container_natural_key,
+    domain_urn,
+)
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
-NaturalKey = Tuple[str, object, str, object, str]
+NaturalKey = tuple[str, object, str, object, str]
 
 
-def topological_sort_containers(containers: List[ContainerDoc]) -> List[ContainerDoc]:
+def topological_sort_containers(containers: list[ContainerDoc]) -> list[ContainerDoc]:
     """Order containers so that every parent precedes its children.
 
     Uses Kahn's algorithm. Containers whose parent isn't itself declared in
@@ -28,11 +32,9 @@ def topological_sort_containers(containers: List[ContainerDoc]) -> List[Containe
     never happen in practice) is broken by appending the remaining nodes in
     their original order, so this always terminates.
     """
-    by_key: Dict[NaturalKey, ContainerDoc] = {
-        container_natural_key(c): c for c in containers
-    }
-    children: Dict[NaturalKey, List[NaturalKey]] = defaultdict(list)
-    indegree: Dict[NaturalKey, int] = dict.fromkeys(by_key, 0)
+    by_key: dict[NaturalKey, ContainerDoc] = {container_natural_key(c): c for c in containers}
+    children: dict[NaturalKey, list[NaturalKey]] = defaultdict(list)
+    indegree: dict[NaturalKey, int] = dict.fromkeys(by_key, 0)
 
     for key, doc in by_key.items():
         if doc.parentContainer is not None:
@@ -42,7 +44,7 @@ def topological_sort_containers(containers: List[ContainerDoc]) -> List[Containe
                 indegree[key] += 1
 
     queue: deque = deque(k for k, d in indegree.items() if d == 0)
-    order: List[ContainerDoc] = []
+    order: list[ContainerDoc] = []
     seen = set()
 
     while queue:
@@ -71,7 +73,8 @@ def build_container(
         if not index.has_container(doc.parentContainer):
             report.report_dangling_reference(
                 f"CONTAINER '{doc.name}' references an undeclared parentContainer "
-                f"(platform={doc.parentContainer.platform}, database={doc.parentContainer.database}, "
+                f"(platform={doc.parentContainer.platform}, "
+                f"database={doc.parentContainer.database}, "
                 f"schema={doc.parentContainer.schema_name})"
             )
         parent_key = container_key(doc.parentContainer)
@@ -85,7 +88,9 @@ def build_container(
     domain = None
     if doc.domains:
         if not index.has_domain(doc.domains):
-            report.report_dangling_reference(f"{context} references undeclared domain '{doc.domains}'")
+            report.report_dangling_reference(
+                f"{context} references undeclared domain '{doc.domains}'"
+            )
         domain = domain_urn(doc.domains)
 
     sub_types = normalize_sub_types(doc.subTypes) or ["container"]
@@ -129,6 +134,10 @@ def build_container(
     # handled above (natively or via the multi-owner fallback), so skip them
     # here to avoid emitting the same aspect twice.
     yield from common_aspect_mcps(
-        key.as_urn(), doc, index, report, context,
+        key.as_urn(),
+        doc,
+        index,
+        report,
+        context,
         skip=frozenset({"owners", "tags", "subTypes", "domain"}),
     )

--- a/src/datahub_yaml_source/builders/dashboard.py
+++ b/src/datahub_yaml_source/builders/dashboard.py
@@ -1,11 +1,17 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.sdk.dashboard import Dashboard
 
 from datahub_yaml_source.builders.common import common_sdk_kwargs, stringify_custom_properties
 from datahub_yaml_source.models import DashboardDoc
-from datahub_yaml_source.urns import ReferenceIndex, chart_urn, container_key, dashboard_urn, dataset_urn
+from datahub_yaml_source.urns import (
+    ReferenceIndex,
+    chart_urn,
+    container_key,
+    dashboard_urn,
+    dataset_urn,
+)
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
 

--- a/src/datahub_yaml_source/builders/data_flow_job.py
+++ b/src/datahub_yaml_source/builders/data_flow_job.py
@@ -1,13 +1,23 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import ContainerClass
 from datahub.sdk.dataflow import DataFlow
 from datahub.sdk.datajob import DataJob
 
-from datahub_yaml_source.builders.common import build_fine_grained_lineage_list, common_sdk_kwargs, stringify_custom_properties
+from datahub_yaml_source.builders.common import (
+    build_fine_grained_lineage_list,
+    common_sdk_kwargs,
+    stringify_custom_properties,
+)
 from datahub_yaml_source.models import DataFlowDoc, DataJobDoc
-from datahub_yaml_source.urns import ReferenceIndex, container_key, data_flow_urn, data_job_urn, dataset_urn
+from datahub_yaml_source.urns import (
+    ReferenceIndex,
+    container_key,
+    data_flow_urn,
+    data_job_urn,
+    dataset_urn,
+)
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
 

--- a/src/datahub_yaml_source/builders/data_process_instance.py
+++ b/src/datahub_yaml_source/builders/data_process_instance.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (

--- a/src/datahub_yaml_source/builders/data_product.py
+++ b/src/datahub_yaml_source/builders/data_product.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import DataProductAssociationClass, DataProductPropertiesClass

--- a/src/datahub_yaml_source/builders/dataset.py
+++ b/src/datahub_yaml_source/builders/dataset.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.emitter.mce_builder import make_schema_field_urn
 from datahub.ingestion.api.workunit import MetadataWorkUnit
@@ -47,9 +47,7 @@ def _build_schema_field(field_doc: SchemaFieldDoc) -> SchemaFieldClass:
 def _build_foreign_key(fk: ForeignKeyDoc) -> ForeignKeyConstraintClass:
     return ForeignKeyConstraintClass(
         name=fk.name,
-        sourceFields=[
-            make_schema_field_urn(dataset_urn(f), f.fieldPath) for f in fk.sourceFields
-        ],
+        sourceFields=[make_schema_field_urn(dataset_urn(f), f.fieldPath) for f in fk.sourceFields],
         foreignFields=[
             make_schema_field_urn(dataset_urn(f), f.fieldPath) for f in fk.foreignFields
         ],
@@ -57,7 +55,9 @@ def _build_foreign_key(fk: ForeignKeyDoc) -> ForeignKeyConstraintClass:
     )
 
 
-def build_schema_metadata(name: str, platform: str, schema_block: SchemaBlock) -> SchemaMetadataClass:
+def build_schema_metadata(
+    name: str, platform: str, schema_block: SchemaBlock
+) -> SchemaMetadataClass:
     return SchemaMetadataClass(
         schemaName=name,
         platform=data_platform_urn(platform),
@@ -75,9 +75,7 @@ def build_schema_metadata(name: str, platform: str, schema_block: SchemaBlock) -
 
 def build_upstream_lineage(doc: UpstreamLineageDoc) -> UpstreamLineageClass:
     upstreams = [
-        UpstreamClass(
-            dataset=dataset_urn(entry.dataset), type=DatasetLineageTypeClass.TRANSFORMED
-        )
+        UpstreamClass(dataset=dataset_urn(entry.dataset), type=DatasetLineageTypeClass.TRANSFORMED)
         for entry in doc.upstreams
     ]
 
@@ -129,9 +127,7 @@ def build_dataset(
         parent_container=parent_container,
         schema=schema_metadata,
         upstreams=upstreams,
-        view_definition=(
-            build_view_properties(doc.viewProperties) if doc.viewProperties else None
-        ),
+        view_definition=(build_view_properties(doc.viewProperties) if doc.viewProperties else None),
         parse_view_lineage=False,
         **common,
     )

--- a/src/datahub_yaml_source/builders/document.py
+++ b/src/datahub_yaml_source/builders/document.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import FrozenSet, Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.sdk.document import Document
@@ -13,7 +13,9 @@ from datahub_yaml_source.yaml_source_report import YamlSourceReport
 # kwarg (unlike Dataset/Chart/Dashboard/DataFlow/DataJob) -- an
 # institutionalMemory aspect a document has still gets emitted, just via
 # `extra_aspects` instead of a constructor kwarg (see `common_sdk_kwargs()`).
-_DOCUMENT_NATIVE_KWARGS: FrozenSet[str] = frozenset({"owners", "tags", "terms", "domain", "subtype"})
+_DOCUMENT_NATIVE_KWARGS: frozenset[str] = frozenset(
+    {"owners", "tags", "terms", "domain", "subtype"}
+)
 
 # Without these, `create_document()`/`create_external_document()` stamp
 # `datetime.now()` on `created`/`lastModified` -- unlike every other SDK V2
@@ -54,7 +56,9 @@ def build_document(
         )
     else:
         if doc.text is None:
-            raise ValueError(f"{context} requires 'text' for a native document (no 'externalUrl' set)")
+            raise ValueError(
+                f"{context} requires 'text' for a native document (no 'externalUrl' set)"
+            )
         document = Document.create_document(
             id=doc.id,
             title=doc.title,

--- a/src/datahub_yaml_source/builders/domain.py
+++ b/src/datahub_yaml_source/builders/domain.py
@@ -1,5 +1,5 @@
 from collections import defaultdict, deque
-from typing import Dict, Iterable, List
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import DisplayPropertiesClass, DomainPropertiesClass
@@ -10,14 +10,14 @@ from datahub_yaml_source.urns import ReferenceIndex, domain_urn
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
 
-def topological_sort_domains(domains: List[DomainDoc]) -> List[DomainDoc]:
+def topological_sort_domains(domains: list[DomainDoc]) -> list[DomainDoc]:
     """Order domains so every parent precedes its children. Kahn's algorithm,
     mirroring `builders.container.topological_sort_containers()`. A domain
     whose `parentDomain` isn't itself declared is treated as a root; any
     cycle is broken by appending the remaining nodes in original order."""
-    by_id: Dict[str, DomainDoc] = {d.id: d for d in domains}
-    children: Dict[str, List[str]] = defaultdict(list)
-    indegree: Dict[str, int] = dict.fromkeys(by_id, 0)
+    by_id: dict[str, DomainDoc] = {d.id: d for d in domains}
+    children: dict[str, list[str]] = defaultdict(list)
+    indegree: dict[str, int] = dict.fromkeys(by_id, 0)
 
     for id_, doc in by_id.items():
         if doc.parentDomain and doc.parentDomain in by_id:
@@ -25,7 +25,7 @@ def topological_sort_domains(domains: List[DomainDoc]) -> List[DomainDoc]:
             indegree[id_] += 1
 
     queue: deque = deque(k for k, d in indegree.items() if d == 0)
-    order: List[DomainDoc] = []
+    order: list[DomainDoc] = []
     seen = set()
 
     while queue:
@@ -53,15 +53,21 @@ def build_domain(
     parent_domain_urn = None
     if doc.parentDomain:
         if not index.has_domain(doc.parentDomain):
-            report.report_dangling_reference(f"{context} references undeclared parentDomain '{doc.parentDomain}'")
+            report.report_dangling_reference(
+                f"{context} references undeclared parentDomain '{doc.parentDomain}'"
+            )
         parent_domain_urn = domain_urn(doc.parentDomain)
 
     yield mcp_workunit(
         entity_urn,
-        DomainPropertiesClass(name=doc.name, description=doc.description, parentDomain=parent_domain_urn),
+        DomainPropertiesClass(
+            name=doc.name, description=doc.description, parentDomain=parent_domain_urn
+        ),
     )
 
     if doc.displayProperties:
-        yield mcp_workunit(entity_urn, DisplayPropertiesClass(colorHex=doc.displayProperties.colorHex))
+        yield mcp_workunit(
+            entity_urn, DisplayPropertiesClass(colorHex=doc.displayProperties.colorHex)
+        )
 
     yield from common_aspect_mcps(entity_urn, doc, index, report, context)

--- a/src/datahub_yaml_source/builders/glossary.py
+++ b/src/datahub_yaml_source/builders/glossary.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import DisplayPropertiesClass
@@ -21,14 +21,20 @@ _GLOSSARY_TERM_NATIVE_KWARGS = frozenset({"owners", "links", "tags", "domain"})
 
 
 def _resolve_related_term_urns(
-    term_ids: Optional[List[str]], index: ReferenceIndex, report: YamlSourceReport, context: str, relation: str
-) -> Optional[List[str]]:
+    term_ids: list[str] | None,
+    index: ReferenceIndex,
+    report: YamlSourceReport,
+    context: str,
+    relation: str,
+) -> list[str] | None:
     if not term_ids:
         return None
     urns = []
     for term_id in term_ids:
         if not index.has_glossary_term(term_id):
-            report.report_dangling_reference(f"{context} references undeclared {relation} '{term_id}'")
+            report.report_dangling_reference(
+                f"{context} references undeclared {relation} '{term_id}'"
+            )
         urns.append(glossary_term_urn(term_id))
     return urns
 
@@ -40,7 +46,9 @@ def build_glossary_node(
     parent_node_urn = None
     if doc.parentNode:
         if not index.has_glossary_node(doc.parentNode):
-            report.report_dangling_reference(f"{context} references undeclared parentNode '{doc.parentNode}'")
+            report.report_dangling_reference(
+                f"{context} references undeclared parentNode '{doc.parentNode}'"
+            )
         parent_node_urn = glossary_node_urn(doc.parentNode)
 
     common = common_sdk_kwargs(doc, index, report, context, native=_GLOSSARY_NODE_NATIVE_KWARGS)
@@ -66,7 +74,9 @@ def build_glossary_term(
     parent_node_urn = None
     if doc.parentNode:
         if not index.has_glossary_node(doc.parentNode):
-            report.report_dangling_reference(f"{context} references undeclared parentNode '{doc.parentNode}'")
+            report.report_dangling_reference(
+                f"{context} references undeclared parentNode '{doc.parentNode}'"
+            )
         parent_node_urn = glossary_node_urn(doc.parentNode)
 
     common = common_sdk_kwargs(doc, index, report, context, native=_GLOSSARY_TERM_NATIVE_KWARGS)
@@ -85,10 +95,18 @@ def build_glossary_term(
         term_source=doc.termSource or "INTERNAL",
         source_ref=doc.sourceRef,
         source_url=doc.sourceUrl,
-        is_a=_resolve_related_term_urns(related.isRelatedTerms, index, report, context, "glossaryRelatedTerms.isRelatedTerms"),
-        has_a=_resolve_related_term_urns(related.hasRelatedTerms, index, report, context, "glossaryRelatedTerms.hasRelatedTerms"),
-        values=_resolve_related_term_urns(related.values, index, report, context, "glossaryRelatedTerms.values"),
-        related_terms=_resolve_related_term_urns(related.relatedTerms, index, report, context, "glossaryRelatedTerms.relatedTerms"),
+        is_a=_resolve_related_term_urns(
+            related.isRelatedTerms, index, report, context, "glossaryRelatedTerms.isRelatedTerms"
+        ),
+        has_a=_resolve_related_term_urns(
+            related.hasRelatedTerms, index, report, context, "glossaryRelatedTerms.hasRelatedTerms"
+        ),
+        values=_resolve_related_term_urns(
+            related.values, index, report, context, "glossaryRelatedTerms.values"
+        ),
+        related_terms=_resolve_related_term_urns(
+            related.relatedTerms, index, report, context, "glossaryRelatedTerms.relatedTerms"
+        ),
         **common,
     )
     yield from term.as_workunits()

--- a/src/datahub_yaml_source/builders/incident.py
+++ b/src/datahub_yaml_source/builders/incident.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
@@ -10,7 +10,12 @@ from datahub.metadata.schema_classes import (
     IncidentStatusClass,
 )
 
-from datahub_yaml_source.builders.common import ZERO_AUDIT_STAMP, common_aspect_mcps, mcp_workunit, owner_urn
+from datahub_yaml_source.builders.common import (
+    ZERO_AUDIT_STAMP,
+    common_aspect_mcps,
+    mcp_workunit,
+    owner_urn,
+)
 from datahub_yaml_source.models import IncidentDoc
 from datahub_yaml_source.urns import ReferenceIndex, incident_urn
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
@@ -40,7 +45,10 @@ def build_incident(
             description=doc.description,
             priority=doc.priority,
             assignees=(
-                [IncidentAssigneeClass(actor=owner_urn(a), assignedAt=ZERO_AUDIT_STAMP) for a in doc.assignees]
+                [
+                    IncidentAssigneeClass(actor=owner_urn(a), assignedAt=ZERO_AUDIT_STAMP)
+                    for a in doc.assignees
+                ]
                 if doc.assignees
                 else None
             ),
@@ -57,7 +65,9 @@ def build_incident(
         yield mcp_workunit(
             entity_urn,
             IncidentNotesClass(
-                notes=[IncidentNoteClass(message=note, created=ZERO_AUDIT_STAMP) for note in doc.notes]
+                notes=[
+                    IncidentNoteClass(message=note, created=ZERO_AUDIT_STAMP) for note in doc.notes
+                ]
             ),
         )
 

--- a/src/datahub_yaml_source/builders/ml.py
+++ b/src/datahub_yaml_source/builders/ml.py
@@ -6,7 +6,7 @@ because the five are tightly interrelated: a feature table references its featur
 primary keys, a model references its model group and its features.
 """
 
-from typing import FrozenSet, Iterable, List
+from collections.abc import Iterable
 
 from datahub.emitter.mce_builder import make_schema_field_urn
 from datahub.ingestion.api.workunit import MetadataWorkUnit
@@ -31,7 +31,12 @@ from datahub.metadata.schema_classes import (
 from datahub.sdk.mlmodel import MLModel
 from datahub.sdk.mlmodelgroup import MLModelGroup
 
-from datahub_yaml_source.builders.common import common_aspect_mcps, common_sdk_kwargs, mcp_workunit, stringify_custom_properties
+from datahub_yaml_source.builders.common import (
+    common_aspect_mcps,
+    common_sdk_kwargs,
+    mcp_workunit,
+    stringify_custom_properties,
+)
 from datahub_yaml_source.models import (
     MLFeatureDoc,
     MLFeatureTableDoc,
@@ -56,7 +61,7 @@ from datahub_yaml_source.yaml_source_report import YamlSourceReport
 # constructor kwargs (verified by signature inspection), unlike Chart/Dashboard/Dataset --
 # all three, plus structuredProperties (as always, C4) and the model card, go via
 # `extra_aspects=` instead.
-_ML_ENTITY_NATIVE_KWARGS: FrozenSet[str] = frozenset({"owners", "tags", "terms", "domain", "links"})
+_ML_ENTITY_NATIVE_KWARGS: frozenset[str] = frozenset({"owners", "tags", "terms", "domain", "links"})
 
 
 def _dataset_or_field_urn(ref: QuerySubjectRef) -> str:
@@ -78,7 +83,9 @@ def build_ml_feature_table(
             customProperties=stringify_custom_properties(doc.properties),
             description=doc.description,
             mlFeatures=[ml_feature_urn(f) for f in doc.mlFeatures] if doc.mlFeatures else None,
-            mlPrimaryKeys=[ml_primary_key_urn(k) for k in doc.mlPrimaryKeys] if doc.mlPrimaryKeys else None,
+            mlPrimaryKeys=[ml_primary_key_urn(k) for k in doc.mlPrimaryKeys]
+            if doc.mlPrimaryKeys
+            else None,
         ),
     )
     yield from common_aspect_mcps(entity_urn, doc, index, report, context)
@@ -147,9 +154,11 @@ def build_ml_model_group(
     yield from group.as_workunits()
 
 
-def _base_data_list(entries: List[MLModelDataDoc]) -> List[BaseDataClass]:
+def _base_data_list(entries: list[MLModelDataDoc]) -> list[BaseDataClass]:
     return [
-        BaseDataClass(dataset=dataset_urn(e.dataset), motivation=e.motivation, preProcessing=e.preProcessing)
+        BaseDataClass(
+            dataset=dataset_urn(e.dataset), motivation=e.motivation, preProcessing=e.preProcessing
+        )
         for e in entries
     ]
 
@@ -173,10 +182,14 @@ def build_ml_model(
     if doc.intendedUse:
         extra_aspects.append(IntendedUseClass(**doc.intendedUse.model_dump(exclude_none=True)))
     if doc.ethicalConsiderations:
-        extra_aspects.append(EthicalConsiderationsClass(**doc.ethicalConsiderations.model_dump(exclude_none=True)))
+        extra_aspects.append(
+            EthicalConsiderationsClass(**doc.ethicalConsiderations.model_dump(exclude_none=True))
+        )
     if doc.caveatsAndRecommendations:
         car = doc.caveatsAndRecommendations
-        caveats = CaveatDetailsClass(**car.caveats.model_dump(exclude_none=True)) if car.caveats else None
+        caveats = (
+            CaveatDetailsClass(**car.caveats.model_dump(exclude_none=True)) if car.caveats else None
+        )
         extra_aspects.append(
             CaveatsAndRecommendationsClass(
                 caveats=caveats,
@@ -187,10 +200,15 @@ def build_ml_model(
     if doc.trainingData:
         extra_aspects.append(TrainingDataClass(trainingData=_base_data_list(doc.trainingData)))
     if doc.evaluationData:
-        extra_aspects.append(EvaluationDataClass(evaluationData=_base_data_list(doc.evaluationData)))
+        extra_aspects.append(
+            EvaluationDataClass(evaluationData=_base_data_list(doc.evaluationData))
+        )
     if doc.factorPrompts:
+
         def _factors(f) -> MLModelFactorsClass:
-            return MLModelFactorsClass(groups=f.groups, instrumentation=f.instrumentation, environment=f.environment)
+            return MLModelFactorsClass(
+                groups=f.groups, instrumentation=f.instrumentation, environment=f.environment
+            )
 
         extra_aspects.append(
             MLModelFactorPromptsClass(
@@ -216,7 +234,10 @@ def build_ml_model(
     if doc.sourceCode:
         extra_aspects.append(
             SourceCodeClass(
-                sourceCode=[SourceCodeUrlClass(type=s.type, sourceCodeUrl=s.sourceCodeUrl) for s in doc.sourceCode]
+                sourceCode=[
+                    SourceCodeUrlClass(type=s.type, sourceCodeUrl=s.sourceCodeUrl)
+                    for s in doc.sourceCode
+                ]
             )
         )
 

--- a/src/datahub_yaml_source/builders/platform.py
+++ b/src/datahub_yaml_source/builders/platform.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import DataPlatformInfoClass

--- a/src/datahub_yaml_source/builders/query.py
+++ b/src/datahub_yaml_source/builders/query.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.emitter.mce_builder import make_schema_field_urn
 from datahub.ingestion.api.workunit import MetadataWorkUnit

--- a/src/datahub_yaml_source/builders/raw_aspect.py
+++ b/src/datahub_yaml_source/builders/raw_aspect.py
@@ -10,7 +10,8 @@ small, extensible registry: add a new `_build_<aspect>` function and register
 it to support another aspect.
 """
 
-from typing import Any, Dict, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Any
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
@@ -34,7 +35,7 @@ from datahub_yaml_source.models import DatasetRef, RawAspectDoc
 from datahub_yaml_source.urns import dataset_urn, owner_urn
 
 
-def _build_field_profile(raw: Dict[str, Any]) -> DatasetFieldProfileClass:
+def _build_field_profile(raw: dict[str, Any]) -> DatasetFieldProfileClass:
     distinct_value_frequencies = None
     if raw.get("distinctValueFrequencies"):
         distinct_value_frequencies = [
@@ -54,20 +55,20 @@ def _build_field_profile(raw: Dict[str, Any]) -> DatasetFieldProfileClass:
     )
 
 
-def _build_event_granularity(raw: Optional[Dict[str, Any]]) -> Optional[TimeWindowSizeClass]:
+def _build_event_granularity(raw: dict[str, Any] | None) -> TimeWindowSizeClass | None:
     if not raw:
         return None
     return TimeWindowSizeClass(unit=raw["unit"], multiple=raw.get("multiple"))
 
 
-def _build_partition_spec(raw: Optional[Dict[str, Any]]) -> Optional[PartitionSpecClass]:
+def _build_partition_spec(raw: dict[str, Any] | None) -> PartitionSpecClass | None:
     if not raw:
         return None
     return PartitionSpecClass(partition=raw["partition"], type=raw.get("type"))
 
 
-def _build_dataset_profile(payload: Dict[str, Any]) -> DatasetProfileClass:
-    field_profiles: Optional[List[DatasetFieldProfileClass]] = None
+def _build_dataset_profile(payload: dict[str, Any]) -> DatasetProfileClass:
+    field_profiles: list[DatasetFieldProfileClass] | None = None
     if payload.get("fieldProfiles"):
         field_profiles = [_build_field_profile(f) for f in payload["fieldProfiles"]]
 
@@ -83,7 +84,7 @@ def _build_dataset_profile(payload: Dict[str, Any]) -> DatasetProfileClass:
     )
 
 
-def _build_operation(payload: Dict[str, Any]) -> OperationClass:
+def _build_operation(payload: dict[str, Any]) -> OperationClass:
     affected_datasets = None
     if payload.get("affectedDatasets"):
         affected_datasets = [
@@ -107,7 +108,7 @@ def _build_operation(payload: Dict[str, Any]) -> OperationClass:
     )
 
 
-def _build_dataset_usage_statistics(payload: Dict[str, Any]) -> DatasetUsageStatisticsClass:
+def _build_dataset_usage_statistics(payload: dict[str, Any]) -> DatasetUsageStatisticsClass:
     user_counts = None
     if payload.get("userCounts"):
         user_counts = [
@@ -137,7 +138,9 @@ def _build_dataset_usage_statistics(payload: Dict[str, Any]) -> DatasetUsageStat
     )
 
 
-def _build_assertion_run_event(payload: Dict[str, Any], assertion_urn: str) -> AssertionRunEventClass:
+def _build_assertion_run_event(
+    payload: dict[str, Any], assertion_urn: str
+) -> AssertionRunEventClass:
     result = None
     if payload.get("result"):
         result = AssertionResultClass(
@@ -159,7 +162,7 @@ def _build_assertion_run_event(payload: Dict[str, Any], assertion_urn: str) -> A
 
 
 def _build_data_process_instance_run_event(
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
 ) -> DataProcessInstanceRunEventClass:
     result = None
     if payload.get("result"):

--- a/src/datahub_yaml_source/builders/semantic.py
+++ b/src/datahub_yaml_source/builders/semantic.py
@@ -1,6 +1,6 @@
 """Builders for the semantic-layer family: SEMANTIC_MODEL, METRIC (Phase 5B)."""
 
-from typing import FrozenSet, Iterable, Optional
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import EdgeClass, MetricUpstreamsClass
@@ -17,10 +17,12 @@ from datahub_yaml_source.yaml_source_report import YamlSourceReport
 # permitting subTypes/applications on both -- native= is narrowed the same way, and
 # externalUrl (present on both info aspects but not as a kwarg either) is set via the
 # same `_ensure_*()` post-construction pattern used for MLModel's type/hyperParameters.
-_SEMANTIC_ENTITY_NATIVE_KWARGS: FrozenSet[str] = frozenset({"owners", "tags", "terms", "domain", "links"})
+_SEMANTIC_ENTITY_NATIVE_KWARGS: frozenset[str] = frozenset(
+    {"owners", "tags", "terms", "domain", "links"}
+)
 
 
-def _ai_context_input(doc: Optional[AiContextDoc]) -> Optional[AiContextInput]:
+def _ai_context_input(doc: AiContextDoc | None) -> AiContextInput | None:
     if doc is None:
         return None
     return AiContextInput(
@@ -55,7 +57,9 @@ def build_semantic_model(
     yield from model.as_workunits()
 
 
-def build_metric(doc: MetricDoc, index: ReferenceIndex, report: YamlSourceReport) -> Iterable[MetadataWorkUnit]:
+def build_metric(
+    doc: MetricDoc, index: ReferenceIndex, report: YamlSourceReport
+) -> Iterable[MetadataWorkUnit]:
     context = f"METRIC '{doc.id}'"
     common = common_sdk_kwargs(doc, index, report, context, native=_SEMANTIC_ENTITY_NATIVE_KWARGS)
 
@@ -65,7 +69,9 @@ def build_metric(doc: MetricDoc, index: ReferenceIndex, report: YamlSourceReport
     if doc.datasetUpstreams:
         extra_aspects.append(
             MetricUpstreamsClass(
-                datasetUpstreams=[EdgeClass(destinationUrn=dataset_urn(d)) for d in doc.datasetUpstreams]
+                datasetUpstreams=[
+                    EdgeClass(destinationUrn=dataset_urn(d)) for d in doc.datasetUpstreams
+                ]
             )
         )
     common["extra_aspects"] = extra_aspects or None
@@ -92,6 +98,8 @@ def build_metric(doc: MetricDoc, index: ReferenceIndex, report: YamlSourceReport
     # as MLModel's `type`/`hyperParameters` (C9).
     if doc.relatedMetrics:
         relationships = metric._ensure_metric_relationships()
-        relationships.relatedMetrics = [EdgeClass(destinationUrn=metric_urn(m)) for m in doc.relatedMetrics]
+        relationships.relatedMetrics = [
+            EdgeClass(destinationUrn=metric_urn(m)) for m in doc.relatedMetrics
+        ]
 
     yield from metric.as_workunits()

--- a/src/datahub_yaml_source/builders/software.py
+++ b/src/datahub_yaml_source/builders/software.py
@@ -7,7 +7,7 @@ None of these five have an SDK V2 wrapper (verified: no matching module under
 no platform component, unlike every dataset-shaped kind in this connector.
 """
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
@@ -70,7 +70,9 @@ def build_repository(
     if doc.source:
         yield mcp_workunit(
             entity_urn,
-            RepositorySourceClass(externalUrl=doc.source.externalUrl, externalId=doc.source.externalId),
+            RepositorySourceClass(
+                externalUrl=doc.source.externalUrl, externalId=doc.source.externalId
+            ),
         )
     if doc.forkOf:
         yield mcp_workunit(entity_urn, RepositoryLineageClass(forkOf=repository_urn(doc.forkOf)))
@@ -82,7 +84,9 @@ def build_repository(
     yield from common_aspect_mcps(entity_urn, doc, index, report, context)
 
 
-def build_api(doc: ApiDoc, index: ReferenceIndex, report: YamlSourceReport) -> Iterable[MetadataWorkUnit]:
+def build_api(
+    doc: ApiDoc, index: ReferenceIndex, report: YamlSourceReport
+) -> Iterable[MetadataWorkUnit]:
     context = f"API '{doc.id}'"
     entity_urn = api_urn(doc.id)
 
@@ -101,7 +105,9 @@ def build_api(doc: ApiDoc, index: ReferenceIndex, report: YamlSourceReport) -> I
             RestApiPropertiesClass(method=doc.restApi.method, path=doc.restApi.path),
         )
     if doc.signature:
-        yield mcp_workunit(entity_urn, ApiSignatureClass(schemaDefinition=doc.signature.schemaDefinition))
+        yield mcp_workunit(
+            entity_urn, ApiSignatureClass(schemaDefinition=doc.signature.schemaDefinition)
+        )
 
     dpi = build_data_platform_instance_aspect(doc.platform, doc.instance)
     if dpi:
@@ -120,7 +126,9 @@ def build_agent_skill(
     if doc.sourceRepository:
         source_repository = SkillSourceRepositoryClass(
             repositoryUrn=(
-                repository_urn(doc.sourceRepository.repositoryUrn) if doc.sourceRepository.repositoryUrn else None
+                repository_urn(doc.sourceRepository.repositoryUrn)
+                if doc.sourceRepository.repositoryUrn
+                else None
             ),
             url=doc.sourceRepository.url,
             path=doc.sourceRepository.path,
@@ -189,7 +197,9 @@ def build_ai_agent(
         )
 
     if doc.displayProperties:
-        yield mcp_workunit(entity_urn, DisplayPropertiesClass(colorHex=doc.displayProperties.colorHex))
+        yield mcp_workunit(
+            entity_urn, DisplayPropertiesClass(colorHex=doc.displayProperties.colorHex)
+        )
 
     dpi = build_data_platform_instance_aspect(doc.platform, doc.instance)
     if dpi:

--- a/src/datahub_yaml_source/builders/structured_property.py
+++ b/src/datahub_yaml_source/builders/structured_property.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
@@ -18,8 +18,7 @@ def build_structured_property(
     allowed_values = None
     if doc.allowedValues:
         allowed_values = [
-            PropertyValueClass(value=v.value, description=v.description)
-            for v in doc.allowedValues
+            PropertyValueClass(value=v.value, description=v.description) for v in doc.allowedValues
         ]
 
     # The friendly YAML shorthand for typeQualifier is a flat list of allowed

--- a/src/datahub_yaml_source/builders/tag.py
+++ b/src/datahub_yaml_source/builders/tag.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.sdk.tag import Tag

--- a/src/datahub_yaml_source/loader.py
+++ b/src/datahub_yaml_source/loader.py
@@ -17,15 +17,15 @@ reason.
 import logging
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union
+from typing import Any
 from urllib.parse import urlparse
 
 import yaml
-from pydantic import ValidationError
-
 from datahub.ingestion.source.aws.s3_util import is_s3_uri
+from pydantic import ValidationError
 
 from datahub_yaml_source.models import (
     AgentSkillDoc,
@@ -77,7 +77,7 @@ OnFileScannedCallback = Callable[[str], None]
 # Callback invoked for every entity document with a field that's either
 # misspelled or not valid for its `kind`: (file_path, kind, field_names) -> None.
 # Not used for RawAspectDoc, whose extra fields *are* the intended payload.
-OnUnknownFieldsCallback = Callable[[str, str, List[str]], None]
+OnUnknownFieldsCallback = Callable[[str, str, list[str]], None]
 
 _HTTP_URI_PATTERN = re.compile(r"^https?://", re.IGNORECASE)
 _GLOB_CHARACTERS = frozenset("*?[]")
@@ -99,38 +99,38 @@ class FileSizeExceededError(ValueError):
 
 @dataclass
 class ParsedRepository:
-    platforms: List[DataPlatformDoc] = field(default_factory=list)
-    tags: List[TagDoc] = field(default_factory=list)
-    glossary_nodes: List[GlossaryNodeDoc] = field(default_factory=list)
-    glossary_terms: List[GlossaryTermDoc] = field(default_factory=list)
-    structured_properties: List[StructuredPropertyDoc] = field(default_factory=list)
-    domains: List[DomainDoc] = field(default_factory=list)
-    applications: List[ApplicationDoc] = field(default_factory=list)
-    containers: List[ContainerDoc] = field(default_factory=list)
-    datasets: List[DatasetDoc] = field(default_factory=list)
-    charts: List[ChartDoc] = field(default_factory=list)
-    dashboards: List[DashboardDoc] = field(default_factory=list)
-    queries: List[QueryDoc] = field(default_factory=list)
-    incidents: List[IncidentDoc] = field(default_factory=list)
-    documents: List[DocumentDoc] = field(default_factory=list)
-    ml_feature_tables: List[MLFeatureTableDoc] = field(default_factory=list)
-    ml_features: List[MLFeatureDoc] = field(default_factory=list)
-    ml_primary_keys: List[MLPrimaryKeyDoc] = field(default_factory=list)
-    ml_model_groups: List[MLModelGroupDoc] = field(default_factory=list)
-    ml_models: List[MLModelDoc] = field(default_factory=list)
-    semantic_models: List[SemanticModelDoc] = field(default_factory=list)
-    metrics: List[MetricDoc] = field(default_factory=list)
-    repositories: List[RepositoryDoc] = field(default_factory=list)
-    apis: List[ApiDoc] = field(default_factory=list)
-    agent_skills: List[AgentSkillDoc] = field(default_factory=list)
-    ai_agents: List[AIAgentDoc] = field(default_factory=list)
-    services: List[ServiceDoc] = field(default_factory=list)
-    data_products: List[DataProductDoc] = field(default_factory=list)
-    data_flows: List[DataFlowDoc] = field(default_factory=list)
-    data_jobs: List[DataJobDoc] = field(default_factory=list)
-    data_process_instances: List[DataProcessInstanceDoc] = field(default_factory=list)
-    assertions: List[AssertionDoc] = field(default_factory=list)
-    raw_aspects: List[RawAspectDoc] = field(default_factory=list)
+    platforms: list[DataPlatformDoc] = field(default_factory=list)
+    tags: list[TagDoc] = field(default_factory=list)
+    glossary_nodes: list[GlossaryNodeDoc] = field(default_factory=list)
+    glossary_terms: list[GlossaryTermDoc] = field(default_factory=list)
+    structured_properties: list[StructuredPropertyDoc] = field(default_factory=list)
+    domains: list[DomainDoc] = field(default_factory=list)
+    applications: list[ApplicationDoc] = field(default_factory=list)
+    containers: list[ContainerDoc] = field(default_factory=list)
+    datasets: list[DatasetDoc] = field(default_factory=list)
+    charts: list[ChartDoc] = field(default_factory=list)
+    dashboards: list[DashboardDoc] = field(default_factory=list)
+    queries: list[QueryDoc] = field(default_factory=list)
+    incidents: list[IncidentDoc] = field(default_factory=list)
+    documents: list[DocumentDoc] = field(default_factory=list)
+    ml_feature_tables: list[MLFeatureTableDoc] = field(default_factory=list)
+    ml_features: list[MLFeatureDoc] = field(default_factory=list)
+    ml_primary_keys: list[MLPrimaryKeyDoc] = field(default_factory=list)
+    ml_model_groups: list[MLModelGroupDoc] = field(default_factory=list)
+    ml_models: list[MLModelDoc] = field(default_factory=list)
+    semantic_models: list[SemanticModelDoc] = field(default_factory=list)
+    metrics: list[MetricDoc] = field(default_factory=list)
+    repositories: list[RepositoryDoc] = field(default_factory=list)
+    apis: list[ApiDoc] = field(default_factory=list)
+    agent_skills: list[AgentSkillDoc] = field(default_factory=list)
+    ai_agents: list[AIAgentDoc] = field(default_factory=list)
+    services: list[ServiceDoc] = field(default_factory=list)
+    data_products: list[DataProductDoc] = field(default_factory=list)
+    data_flows: list[DataFlowDoc] = field(default_factory=list)
+    data_jobs: list[DataJobDoc] = field(default_factory=list)
+    data_process_instances: list[DataProcessInstanceDoc] = field(default_factory=list)
+    assertions: list[AssertionDoc] = field(default_factory=list)
+    raw_aspects: list[RawAspectDoc] = field(default_factory=list)
 
     def add(self, doc: object) -> None:
         if isinstance(doc, DataPlatformDoc):
@@ -201,7 +201,7 @@ class ParsedRepository:
             raise TypeError(f"Unrecognized parsed document type: {type(doc)}")
 
 
-def _discover_s3_files(prefix: str, aws_connection: Optional[Any]) -> List[str]:
+def _discover_s3_files(prefix: str, aws_connection: Any | None) -> list[str]:
     """List every '*.yml' / '*.yaml' object under an s3:// prefix.
 
     Lists by prefix (paginated `list_objects_v2`) rather than using DataHub's
@@ -220,7 +220,7 @@ def _discover_s3_files(prefix: str, aws_connection: Optional[Any]) -> List[str]:
     client = aws_connection.get_s3_client()
     paginator = client.get_paginator("list_objects_v2")
 
-    keys: List[str] = []
+    keys: list[str] = []
     for page in paginator.paginate(Bucket=bucket, Prefix=key_prefix):
         for obj in page.get("Contents", []):
             key = obj["Key"]
@@ -230,7 +230,7 @@ def _discover_s3_files(prefix: str, aws_connection: Optional[Any]) -> List[str]:
     return sorted(f"s3://{bucket}/{key}" for key in keys)
 
 
-def _read_s3_bytes(uri: str, aws_connection: Optional[Any], max_bytes: Optional[int]) -> bytes:
+def _read_s3_bytes(uri: str, aws_connection: Any | None, max_bytes: int | None) -> bytes:
     if aws_connection is None:
         raise ValueError(f"'aws_connection' is required to read S3 path: {uri}")
 
@@ -257,19 +257,23 @@ def _read_s3_bytes(uri: str, aws_connection: Optional[Any], max_bytes: Optional[
     return data
 
 
-def _read_http_bytes(uri: str, http_connection: Optional[Any], max_bytes: Optional[int]) -> bytes:
+def _read_http_bytes(uri: str, http_connection: Any | None, max_bytes: int | None) -> bytes:
     import requests
 
     kwargs = http_connection.to_request_kwargs() if http_connection else {}
     with requests.get(uri, timeout=_HTTP_TIMEOUT_SECONDS, stream=True, **kwargs) as resp:
         resp.raise_for_status()
         declared = resp.headers.get("Content-Length")
-        if declared is not None and declared.isdigit() and max_bytes is not None:
-            if int(declared) > max_bytes:
-                raise FileSizeExceededError(
-                    f"{uri} is {declared} bytes, over the configured "
-                    f"max_input_file_bytes limit of {max_bytes}"
-                )
+        if (
+            declared is not None
+            and declared.isdigit()
+            and max_bytes is not None
+            and int(declared) > max_bytes
+        ):
+            raise FileSizeExceededError(
+                f"{uri} is {declared} bytes, over the configured "
+                f"max_input_file_bytes limit of {max_bytes}"
+            )
         buffer = bytearray()
         for chunk in resp.iter_content(chunk_size=_HTTP_CHUNK_BYTES):
             buffer.extend(chunk)
@@ -280,7 +284,7 @@ def _read_http_bytes(uri: str, http_connection: Optional[Any], max_bytes: Option
         return bytes(buffer)
 
 
-def discover_yaml_files(root: Union[str, Path], aws_connection: Optional[Any] = None) -> List[str]:
+def discover_yaml_files(root: str | Path, aws_connection: Any | None = None) -> list[str]:
     """Resolve one configured 'path' entry into the file URIs to read from it.
 
     - A local directory is scanned recursively for '*.yml' / '*.yaml' files
@@ -312,13 +316,13 @@ def discover_yaml_files(root: Union[str, Path], aws_connection: Optional[Any] = 
 
 
 def load_repository(
-    roots: Union[str, Path, List[Union[str, Path]]],
+    roots: str | Path | list[str | Path],
     on_error: OnErrorCallback,
-    on_file_scanned: Optional[OnFileScannedCallback] = None,
-    on_unknown_fields: Optional[OnUnknownFieldsCallback] = None,
-    aws_connection: Optional[Any] = None,
-    http_connection: Optional[Any] = None,
-    max_input_file_bytes: Optional[int] = None,
+    on_file_scanned: OnFileScannedCallback | None = None,
+    on_unknown_fields: OnUnknownFieldsCallback | None = None,
+    aws_connection: Any | None = None,
+    http_connection: Any | None = None,
+    max_input_file_bytes: int | None = None,
 ) -> ParsedRepository:
     """Resolve every entry in `roots` to file URIs and parse every document in
     every file into a ParsedRepository.
@@ -354,9 +358,7 @@ def load_repository(
                         "utf-8"
                     )
                 elif is_s3_uri(uri):
-                    text = _read_s3_bytes(uri, aws_connection, max_input_file_bytes).decode(
-                        "utf-8"
-                    )
+                    text = _read_s3_bytes(uri, aws_connection, max_input_file_bytes).decode("utf-8")
                 else:
                     file_path = Path(uri)
                     if max_input_file_bytes is not None:

--- a/src/datahub_yaml_source/models.py
+++ b/src/datahub_yaml_source/models.py
@@ -9,7 +9,7 @@ These models only describe the on-disk shape of the YAML. Translation into
 DataHub aspects/URNs happens in `datahub_yaml_source.builders.*`.
 """
 
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
@@ -22,7 +22,7 @@ def _coerce_to_list(value: Any) -> Any:
     return [value]
 
 
-StringList = Annotated[List[str], BeforeValidator(_coerce_to_list)]
+StringList = Annotated[list[str], BeforeValidator(_coerce_to_list)]
 
 
 class OwnerEntry(BaseModel):
@@ -30,10 +30,10 @@ class OwnerEntry(BaseModel):
     type: str = "TECHNICAL_OWNER"
 
 
-OwnersField = Union[OwnerEntry, List[OwnerEntry]]
+OwnersField = OwnerEntry | list[OwnerEntry]
 
 
-def normalize_owners(owners: Optional[OwnersField]) -> List[OwnerEntry]:
+def normalize_owners(owners: OwnersField | None) -> list[OwnerEntry]:
     if owners is None:
         return []
     if isinstance(owners, OwnerEntry):
@@ -41,10 +41,10 @@ def normalize_owners(owners: Optional[OwnersField]) -> List[OwnerEntry]:
     return owners
 
 
-SubTypesField = Union[str, List[str]]
+SubTypesField = str | list[str]
 
 
-def normalize_sub_types(sub_types: Optional[SubTypesField]) -> List[str]:
+def normalize_sub_types(sub_types: SubTypesField | None) -> list[str]:
     if sub_types is None:
         return []
     if isinstance(sub_types, str):
@@ -58,7 +58,7 @@ class DatasetRef(BaseModel):
     platform: str
     name: str
     env: str = "PROD"
-    instance: Optional[str] = None
+    instance: str | None = None
 
 
 class DatasetFieldRef(DatasetRef):
@@ -77,11 +77,11 @@ class ContainerRef(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     platform: str = Field(description="Platform of the container, e.g. 'postgres', 'duckdb', 's3'.")
-    instance: Optional[str] = Field(
+    instance: str | None = Field(
         default=None, description="Platform instance name. Does not affect the container's URN."
     )
-    database: Optional[str] = None
-    schema_name: Optional[str] = Field(default=None, alias="schema")
+    database: str | None = None
+    schema_name: str | None = Field(default=None, alias="schema")
     env: str = Field(default="PROD", description="Does not affect the container's URN.")
 
 
@@ -89,9 +89,11 @@ class ForeignKeyDoc(BaseModel):
     """A foreign key constraint from this dataset's schema to another dataset."""
 
     name: str
-    sourceFields: List[DatasetFieldRef] = Field(default_factory=list, description="Column(s) on this dataset.")
+    sourceFields: list[DatasetFieldRef] = Field(
+        default_factory=list, description="Column(s) on this dataset."
+    )
     foreignDataset: DatasetRef = Field(description="The dataset the foreign key points to.")
-    foreignFields: List[DatasetFieldRef] = Field(
+    foreignFields: list[DatasetFieldRef] = Field(
         default_factory=list, description="Column(s) on the foreign dataset."
     )
 
@@ -107,7 +109,7 @@ class ViewPropertiesDoc(BaseModel):
     viewLogic: str = Field(description="The view's definition, e.g. its SELECT statement.")
     viewLanguage: str = Field(default="SQL", description="e.g. 'SQL'.")
     materialized: bool = Field(default=False, description="True for a materialized view.")
-    formattedViewLogic: Optional[str] = Field(
+    formattedViewLogic: str | None = Field(
         default=None, description="Optional pretty-printed/formatted version of viewLogic."
     )
 
@@ -115,14 +117,16 @@ class ViewPropertiesDoc(BaseModel):
 class FineGrainedLineageDoc(BaseModel):
     """A single column-level lineage edge."""
 
-    upstream: Optional[DatasetFieldRef] = Field(
+    upstream: DatasetFieldRef | None = Field(
         default=None,
         description="Source column. Absent for e.g. operation: CONSTANT, where the downstream "
         "value is a literal with no source column.",
     )
     downstream: DatasetFieldRef
-    operation: Optional[str] = Field(default=None, description="Free-text transform description, e.g. IDENTITY, CONSTANT.")
-    confidence: Optional[float] = 1.0
+    operation: str | None = Field(
+        default=None, description="Free-text transform description, e.g. IDENTITY, CONSTANT."
+    )
+    confidence: float | None = 1.0
 
 
 class UpstreamEntryDoc(BaseModel):
@@ -132,8 +136,10 @@ class UpstreamEntryDoc(BaseModel):
 class UpstreamLineageDoc(BaseModel):
     """Table-level and (optionally) column-level lineage for a dataset."""
 
-    upstreams: List[UpstreamEntryDoc] = Field(default_factory=list, description="Upstream (source) datasets.")
-    fineGrainedLineages: Optional[List[FineGrainedLineageDoc]] = Field(
+    upstreams: list[UpstreamEntryDoc] = Field(
+        default_factory=list, description="Upstream (source) datasets."
+    )
+    fineGrainedLineages: list[FineGrainedLineageDoc] | None = Field(
         default=None, description="Column-level lineage edges."
     )
 
@@ -142,18 +148,22 @@ class LinkDoc(BaseModel):
     """A link surfaced in DataHub's "Links" panel (the `institutionalMemory` aspect)."""
 
     url: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class DeprecationDoc(BaseModel):
     """Marks an entity deprecated. Emits the `deprecation` aspect."""
 
-    deprecated: bool = Field(default=True, description="Set to false to explicitly un-deprecate an entity.")
-    note: Optional[str] = None
-    decommissionTime: Optional[int] = Field(
+    deprecated: bool = Field(
+        default=True, description="Set to false to explicitly un-deprecate an entity."
+    )
+    note: str | None = None
+    decommissionTime: int | None = Field(
         default=None, description="Planned removal time, epoch millis."
     )
-    actor: Optional[str] = Field(default=None, description="Owner name; converted to a corpuser URN if not already one.")
+    actor: str | None = Field(
+        default=None, description="Owner name; converted to a corpuser URN if not already one."
+    )
 
 
 # --- Cross-cutting aspect mixins --------------------------------------------
@@ -189,7 +199,7 @@ class DeprecationDoc(BaseModel):
 #   SERVICE          Y     Y    -     -      -     -      -            -          Y
 #   CONTAINER        Y     Y    Y     Y      Y     Y      Y            Y          Y
 #   DATA_FLOW        Y     Y    Y     Y      Y     Y      Y            Y          Y
-#   DATA_JOB         Y     Y    Y     Y      Y     Y      Y            Y          (via `type`, see DataJobDoc)
+#   DATA_JOB         Y     Y    Y     Y      Y     Y      Y            Y          (via `type`, see DataJobDoc)  # noqa: E501
 #   DATA_PRODUCT     Y     Y    Y     Y      Y     Y      Y            Y          Y
 #   DOMAIN           Y     -    -     -      -     Y      Y            Y          -
 #   APPLICATION      Y     Y    -     Y      -     Y      -            Y          Y
@@ -214,45 +224,47 @@ class _AllowExtraFields(BaseModel):
 
 
 class HasOwners(BaseModel):
-    owners: Optional[OwnersField] = None
+    owners: OwnersField | None = None
 
 
 class HasTags(BaseModel):
-    tags: Optional[StringList] = None
+    tags: StringList | None = None
 
 
 class HasTerms(BaseModel):
-    glossaryTerms: Optional[StringList] = None
+    glossaryTerms: StringList | None = None
 
 
 class HasDomain(BaseModel):
-    domains: Optional[str] = None
+    domains: str | None = None
 
 
 class HasApplications(BaseModel):
-    applications: Optional[StringList] = Field(
+    applications: StringList | None = Field(
         default=None, description="ids of the APPLICATION documents this entity belongs to."
     )
 
 
 class HasLinks(BaseModel):
-    links: Optional[List[LinkDoc]] = Field(
-        default=None, description="Links shown in DataHub's 'Links' panel (the institutionalMemory aspect)."
+    links: list[LinkDoc] | None = Field(
+        default=None,
+        description="Links shown in DataHub's 'Links' panel (the institutionalMemory aspect).",
     )
 
 
 class HasDeprecation(BaseModel):
-    deprecation: Optional[DeprecationDoc] = None
+    deprecation: DeprecationDoc | None = None
 
 
 class HasStructuredProps(BaseModel):
-    structuredProperties: Optional[Dict[str, Any]] = Field(
-        default=None, description="Map of structuredProperty qualifiedName -> value (or list of values)."
+    structuredProperties: dict[str, Any] | None = Field(
+        default=None,
+        description="Map of structuredProperty qualifiedName -> value (or list of values).",
     )
 
 
 class HasSubTypes(BaseModel):
-    subTypes: Optional[SubTypesField] = None
+    subTypes: SubTypesField | None = None
 
 
 class SchemaFieldDoc(HasTags, HasTerms, HasStructuredProps, HasDeprecation, BaseModel):
@@ -265,18 +277,22 @@ class SchemaFieldDoc(HasTags, HasTerms, HasStructuredProps, HasDeprecation, Base
     """
 
     fieldPath: str
-    type: str = Field(description="A DataHub schema type: number, string, boolean, date, time, bytes, record.")
-    description: Optional[str] = None
-    nativeDataType: Optional[str] = Field(default=None, description="The source system's own type name, e.g. VARCHAR(255).")
+    type: str = Field(
+        description="A DataHub schema type: number, string, boolean, date, time, bytes, record."
+    )
+    description: str | None = None
+    nativeDataType: str | None = Field(
+        default=None, description="The source system's own type name, e.g. VARCHAR(255)."
+    )
     partOfKey: bool = False
-    nullable: Optional[bool] = None
+    nullable: bool | None = None
 
 
 class SchemaBlock(BaseModel):
     """A dataset's full schema: its fields and any foreign keys."""
 
-    fields: List[SchemaFieldDoc] = Field(default_factory=list)
-    foreignKeys: Optional[List[ForeignKeyDoc]] = None
+    fields: list[SchemaFieldDoc] = Field(default_factory=list)
+    foreignKeys: list[ForeignKeyDoc] | None = None
 
 
 class DisplayPropertiesDoc(BaseModel):
@@ -284,7 +300,7 @@ class DisplayPropertiesDoc(BaseModel):
     (`icon` is not supported yet -- DataHub's `IconPropertiesClass` needs an
     icon library/name/style triple with no natural single-field shorthand.)"""
 
-    colorHex: Optional[str] = None
+    colorHex: str | None = None
 
 
 class DataPlatformDoc(_AllowExtraFields):
@@ -293,10 +309,15 @@ class DataPlatformDoc(_AllowExtraFields):
     or `duckdb` -- only for platforms DataHub doesn't already know about."""
 
     kind: Literal["DATA_PLATFORM"]
-    name: str = Field(description="Platform identifier, e.g. 'pathling'. Becomes urn:li:dataPlatform:<name>.")
-    displayName: Optional[str] = None
-    type: str = Field(default="OTHERS", description="One of DataHub's PlatformType enum values, e.g. RELATIONAL_DB, OTHERS.")
-    logoUrl: Optional[str] = None
+    name: str = Field(
+        description="Platform identifier, e.g. 'pathling'. Becomes urn:li:dataPlatform:<name>."
+    )
+    displayName: str | None = None
+    type: str = Field(
+        default="OTHERS",
+        description="One of DataHub's PlatformType enum values, e.g. RELATIONAL_DB, OTHERS.",
+    )
+    logoUrl: str | None = None
     datasetNameDelimiter: str = "."
 
 
@@ -305,33 +326,58 @@ class TagDoc(HasOwners, HasDeprecation, _AllowExtraFields):
 
     kind: Literal["TAG"]
     name: str
-    description: Optional[str] = None
-    colorHex: Optional[str] = None
+    description: str | None = None
+    colorHex: str | None = None
 
 
-class GlossaryNodeDoc(HasOwners, HasTags, HasDomain, HasLinks, HasStructuredProps, HasSubTypes, _AllowExtraFields):
+class GlossaryNodeDoc(
+    HasOwners, HasTags, HasDomain, HasLinks, HasStructuredProps, HasSubTypes, _AllowExtraFields
+):
     """A glossary category/folder that groups related glossary terms."""
 
     kind: Literal["GLOSSARY_NODE"]
-    id: str = Field(description="Stable identifier, becomes urn:li:glossaryNode:<id>. Referenced via 'parentNode'.")
+    id: str = Field(
+        description=(
+            "Stable identifier, becomes urn:li:glossaryNode:<id>. Referenced via 'parentNode'."
+        )
+    )
     name: str
-    definition: Optional[str] = None
-    parentNode: Optional[str] = Field(default=None, description="id of a parent GLOSSARY_NODE, for nested categories.")
-    displayProperties: Optional[DisplayPropertiesDoc] = None
+    definition: str | None = None
+    parentNode: str | None = Field(
+        default=None, description="id of a parent GLOSSARY_NODE, for nested categories."
+    )
+    displayProperties: DisplayPropertiesDoc | None = None
 
 
 class GlossaryRelatedTermsDoc(BaseModel):
     """Relationships to other glossary terms. Emits the `glossaryRelatedTerms`
     aspect. Each list holds ids of other GLOSSARY_TERM documents."""
 
-    isRelatedTerms: Optional[StringList] = Field(default=None, description="'is a' relationships, e.g. this term is a kind of the related term.")
-    hasRelatedTerms: Optional[StringList] = Field(default=None, description="'has a' relationships, e.g. this term has the related term as a part.")
-    values: Optional[StringList] = Field(default=None, description="Related terms representing possible values of this term.")
-    relatedTerms: Optional[StringList] = Field(default=None, description="General 'is related to' relationships.")
+    isRelatedTerms: StringList | None = Field(
+        default=None,
+        description="'is a' relationships, e.g. this term is a kind of the related term.",
+    )
+    hasRelatedTerms: StringList | None = Field(
+        default=None,
+        description="'has a' relationships, e.g. this term has the related term as a part.",
+    )
+    values: StringList | None = Field(
+        default=None, description="Related terms representing possible values of this term."
+    )
+    relatedTerms: StringList | None = Field(
+        default=None, description="General 'is related to' relationships."
+    )
 
 
 class GlossaryTermDoc(
-    HasOwners, HasTags, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps, HasSubTypes,
+    HasOwners,
+    HasTags,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
     _AllowExtraFields,
 ):
     """A glossary term. Referenced elsewhere via `glossaryTerms: [<id>]`."""
@@ -339,26 +385,31 @@ class GlossaryTermDoc(
     kind: Literal["GLOSSARY_TERM"]
     id: str = Field(description="Stable identifier, becomes urn:li:glossaryTerm:<id>.")
     name: str
-    definition: Optional[str] = None
-    parentNode: Optional[str] = Field(default=None, description="id of the GLOSSARY_NODE this term belongs to.")
-    glossaryRelatedTerms: Optional[GlossaryRelatedTermsDoc] = None
-    termSource: Optional[str] = Field(default=None, description="e.g. 'EXTERNAL' or 'INTERNAL'.")
-    sourceRef: Optional[str] = Field(default=None, description="Name of the external source this term came from, if termSource is EXTERNAL.")
-    sourceUrl: Optional[str] = None
-    displayProperties: Optional[DisplayPropertiesDoc] = None
+    definition: str | None = None
+    parentNode: str | None = Field(
+        default=None, description="id of the GLOSSARY_NODE this term belongs to."
+    )
+    glossaryRelatedTerms: GlossaryRelatedTermsDoc | None = None
+    termSource: str | None = Field(default=None, description="e.g. 'EXTERNAL' or 'INTERNAL'.")
+    sourceRef: str | None = Field(
+        default=None,
+        description="Name of the external source this term came from, if termSource is EXTERNAL.",
+    )
+    sourceUrl: str | None = None
+    displayProperties: DisplayPropertiesDoc | None = None
 
 
 class AllowedValueDoc(BaseModel):
     value: Any
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class StructuredPropertySettingsDoc(BaseModel):
-    showInAssetSummary: Optional[bool] = None
-    showInSearchFilters: Optional[bool] = None
-    showInColumnsTable: Optional[bool] = None
-    showAsAssetBadge: Optional[bool] = None
-    isHidden: Optional[bool] = None
+    showInAssetSummary: bool | None = None
+    showInSearchFilters: bool | None = None
+    showInColumnsTable: bool | None = None
+    showAsAssetBadge: bool | None = None
+    isHidden: bool | None = None
 
 
 class StructuredPropertyDoc(_AllowExtraFields):
@@ -367,24 +418,32 @@ class StructuredPropertyDoc(_AllowExtraFields):
     """
 
     kind: Literal["STRUCTURED_PROPERTY"]
-    qualifiedName: str = Field(description="Globally unique dotted name, e.g. 'org.example.legalBasis'.")
-    displayName: Optional[str] = None
-    description: Optional[str] = None
-    cardinality: str = Field(default="SINGLE", description="SINGLE or MULTIPLE values allowed per entity.")
-    valueType: str = Field(description="One of DataHub's data types: string, number, date, rich_text, urn, ...")
-    allowedValues: Optional[List[AllowedValueDoc]] = Field(
+    qualifiedName: str = Field(
+        description="Globally unique dotted name, e.g. 'org.example.legalBasis'."
+    )
+    displayName: str | None = None
+    description: str | None = None
+    cardinality: str = Field(
+        default="SINGLE", description="SINGLE or MULTIPLE values allowed per entity."
+    )
+    valueType: str = Field(
+        description="One of DataHub's data types: string, number, date, rich_text, urn, ..."
+    )
+    allowedValues: list[AllowedValueDoc] | None = Field(
         default=None, description="Restrict to an enum of allowed values; omit to allow any value."
     )
-    entityTypes: List[str] = Field(
+    entityTypes: list[str] = Field(
         default_factory=list,
-        description="Which entity types this property can be attached to, e.g. [dataset, dataProduct].",
+        description=(
+            "Which entity types this property can be attached to, e.g. [dataset, dataProduct]."
+        ),
     )
-    typeQualifier: Optional[List[str]] = Field(
+    typeQualifier: list[str] | None = Field(
         default=None,
         description="For valueType 'urn': list of allowed target entity-type URNs "
         "(e.g. 'urn:li:entityType:datahub.dataProduct'). Maps to the 'allowedTypes' qualifier.",
     )
-    settings: Optional[StructuredPropertySettingsDoc] = Field(
+    settings: StructuredPropertySettingsDoc | None = Field(
         default=None, description="Where this property is surfaced in the DataHub UI."
     )
 
@@ -396,9 +455,11 @@ class DomainDoc(HasOwners, HasLinks, HasDeprecation, HasStructuredProps, _AllowE
     kind: Literal["DOMAIN"]
     id: str = Field(description="Stable identifier, becomes urn:li:domain:<id>.")
     name: str
-    description: Optional[str] = None
-    parentDomain: Optional[str] = Field(default=None, description="id of a parent DOMAIN, for nested domain trees.")
-    displayProperties: Optional[DisplayPropertiesDoc] = None
+    description: str | None = None
+    parentDomain: str | None = Field(
+        default=None, description="id of a parent DOMAIN, for nested domain trees."
+    )
+    displayProperties: DisplayPropertiesDoc | None = None
 
 
 class ApplicationLineageEdgeDoc(BaseModel):
@@ -406,37 +467,48 @@ class ApplicationLineageEdgeDoc(BaseModel):
     or `dataset` must be set -- `applicationLineage`'s underlying edges accept
     either an `api` or a `dataset` entity, never both."""
 
-    api: Optional[str] = Field(default=None, description="id of an API document.")
-    dataset: Optional[DatasetRef] = None
+    api: str | None = Field(default=None, description="id of an API document.")
+    dataset: DatasetRef | None = None
 
 
 class ApplicationLineageDoc(BaseModel):
     """Which APIs/datasets an APPLICATION consumes and produces."""
 
-    consumes: Optional[List[ApplicationLineageEdgeDoc]] = Field(
+    consumes: list[ApplicationLineageEdgeDoc] | None = Field(
         default=None, description="Upstream APIs/datasets this application reads from."
     )
-    produces: Optional[List[ApplicationLineageEdgeDoc]] = Field(
+    produces: list[ApplicationLineageEdgeDoc] | None = Field(
         default=None, description="Downstream APIs/datasets this application writes to."
     )
 
 
-class ApplicationDoc(HasOwners, HasTags, HasDomain, HasLinks, HasStructuredProps, HasSubTypes, _AllowExtraFields):
+class ApplicationDoc(
+    HasOwners, HasTags, HasDomain, HasLinks, HasStructuredProps, HasSubTypes, _AllowExtraFields
+):
     """A source application/system (e.g. an EHR, an ERP). Referenced elsewhere
     via `applications: [<id>]`."""
 
     kind: Literal["APPLICATION"]
     id: str = Field(description="Stable identifier, becomes urn:li:application:<id>.")
     name: str
-    description: Optional[str] = None
-    applicationLineage: Optional[ApplicationLineageDoc] = Field(
+    description: str | None = None
+    applicationLineage: ApplicationLineageDoc | None = Field(
         default=None, description="APIs/datasets this application consumes and produces."
     )
 
 
 class ContainerDoc(
-    ContainerRef, HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation,
-    HasStructuredProps, HasSubTypes, _AllowExtraFields,
+    ContainerRef,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A container (database, schema, bucket, ...). Emitted with parents
     before children automatically, regardless of declaration order across
@@ -444,17 +516,26 @@ class ContainerDoc(
 
     kind: Literal["CONTAINER"]
     name: str
-    description: Optional[str] = None
-    externalUrl: Optional[str] = None
-    parentContainer: Optional[ContainerRef] = Field(
-        default=None, description="Reference to the parent container, if any (e.g. a schema's parent database)."
+    description: str | None = None
+    externalUrl: str | None = None
+    parentContainer: ContainerRef | None = Field(
+        default=None,
+        description="Reference to the parent container, if any (e.g. a schema's parent database).",
     )
-    properties: Optional[Dict[str, Any]] = None
+    properties: dict[str, Any] | None = None
 
 
 class DatasetDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A dataset (table, view, topic, file, ...)."""
 
@@ -464,15 +545,17 @@ class DatasetDoc(
     name: str
     platform: str
     env: str = "PROD"
-    instance: Optional[str] = None
-    displayName: Optional[str] = None
-    description: Optional[str] = None
-    container: Optional[ContainerRef] = Field(default=None, description="The dataset's parent container.")
-    schema_block: Optional[SchemaBlock] = Field(default=None, alias="schema")
-    properties: Optional[Dict[str, Any]] = None
-    externalUrl: Optional[str] = None
-    upstreamLineage: Optional[UpstreamLineageDoc] = None
-    viewProperties: Optional[ViewPropertiesDoc] = Field(
+    instance: str | None = None
+    displayName: str | None = None
+    description: str | None = None
+    container: ContainerRef | None = Field(
+        default=None, description="The dataset's parent container."
+    )
+    schema_block: SchemaBlock | None = Field(default=None, alias="schema")
+    properties: dict[str, Any] | None = None
+    externalUrl: str | None = None
+    upstreamLineage: UpstreamLineageDoc | None = None
+    viewProperties: ViewPropertiesDoc | None = Field(
         default=None,
         description="For views: the view's SQL definition. Set subTypes: View alongside it. "
         "No lineage is inferred from viewLogic -- declare upstreamLineage explicitly if needed.",
@@ -494,60 +577,90 @@ class DashboardRef(BaseModel):
 
 
 class ChartDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A chart/visualization from a BI tool (Superset, Looker, Tableau, ...).
     Referenced from a DASHBOARD's `charts:` field by (platform, name)."""
 
     kind: Literal["CHART"]
-    name: str = Field(description="Chart identifier within its platform. Becomes part of the chart URN.")
+    name: str = Field(
+        description="Chart identifier within its platform. Becomes part of the chart URN."
+    )
     platform: str = Field(description="The BI tool, e.g. 'superset', 'looker', 'tableau'.")
-    instance: Optional[str] = None
-    displayName: Optional[str] = None
-    description: Optional[str] = None
-    chartUrl: Optional[str] = Field(default=None, description="Link to the chart in its native BI tool.")
-    chartType: Optional[str] = Field(
+    instance: str | None = None
+    displayName: str | None = None
+    description: str | None = None
+    chartUrl: str | None = Field(
+        default=None, description="Link to the chart in its native BI tool."
+    )
+    chartType: str | None = Field(
         default=None, description="One of DataHub's ChartType values, e.g. BAR, LINE, PIE, TABLE."
     )
-    externalUrl: Optional[str] = None
-    container: Optional[ContainerRef] = Field(default=None, description="The chart's parent container, if any.")
-    inputDatasets: Optional[List[DatasetRef]] = Field(
+    externalUrl: str | None = None
+    container: ContainerRef | None = Field(
+        default=None, description="The chart's parent container, if any."
+    )
+    inputDatasets: list[DatasetRef] | None = Field(
         default=None, description="Datasets this chart is built from."
     )
-    properties: Optional[Dict[str, Any]] = None
+    properties: dict[str, Any] | None = None
 
 
 class DashboardDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A dashboard: a collection of charts (and/or nested dashboards) from a
     BI tool (Superset, Looker, Tableau, ...)."""
 
     kind: Literal["DASHBOARD"]
-    name: str = Field(description="Dashboard identifier within its platform. Becomes part of the dashboard URN.")
+    name: str = Field(
+        description="Dashboard identifier within its platform. Becomes part of the dashboard URN."
+    )
     platform: str = Field(description="The BI tool, e.g. 'superset', 'looker', 'tableau'.")
-    instance: Optional[str] = None
-    displayName: Optional[str] = None
-    description: Optional[str] = None
-    dashboardUrl: Optional[str] = Field(default=None, description="Link to the dashboard in its native BI tool.")
-    externalUrl: Optional[str] = None
-    container: Optional[ContainerRef] = Field(default=None, description="The dashboard's parent container, if any.")
-    charts: Optional[List[ChartRef]] = Field(default=None, description="Charts shown on this dashboard.")
-    dashboards: Optional[List[DashboardRef]] = Field(
+    instance: str | None = None
+    displayName: str | None = None
+    description: str | None = None
+    dashboardUrl: str | None = Field(
+        default=None, description="Link to the dashboard in its native BI tool."
+    )
+    externalUrl: str | None = None
+    container: ContainerRef | None = Field(
+        default=None, description="The dashboard's parent container, if any."
+    )
+    charts: list[ChartRef] | None = Field(
+        default=None, description="Charts shown on this dashboard."
+    )
+    dashboards: list[DashboardRef] | None = Field(
         default=None, description="Other dashboards nested under this one."
     )
-    inputDatasets: Optional[List[DatasetRef]] = Field(
+    inputDatasets: list[DatasetRef] | None = Field(
         default=None, description="Datasets this dashboard is built from."
     )
-    properties: Optional[Dict[str, Any]] = None
+    properties: dict[str, Any] | None = None
 
 
 class QuerySubjectRef(DatasetRef):
     """A dataset (or, with `fieldPath`, one of its columns) that a QUERY reads."""
 
-    fieldPath: Optional[str] = None
+    fieldPath: str | None = None
 
 
 class QueryDoc(HasSubTypes, _AllowExtraFields):
@@ -556,28 +669,35 @@ class QueryDoc(HasSubTypes, _AllowExtraFields):
 
     kind: Literal["QUERY"]
     id: str = Field(description="Stable identifier, becomes urn:li:query:<id>.")
-    name: Optional[str] = None
-    description: Optional[str] = None
+    name: str | None = None
+    description: str | None = None
     statement: str = Field(description="The query text, e.g. a SQL SELECT statement.")
     language: str = Field(default="SQL", description="SQL or UNKNOWN.")
-    source: str = Field(default="MANUAL", description="MANUAL (hand-authored here) or SYSTEM (observed).")
-    subjects: Optional[List[QuerySubjectRef]] = Field(
+    source: str = Field(
+        default="MANUAL", description="MANUAL (hand-authored here) or SYSTEM (observed)."
+    )
+    subjects: list[QuerySubjectRef] | None = Field(
         default=None, description="Datasets/columns this query reads."
     )
 
 
 class IncidentStatusDoc(BaseModel):
     state: str = Field(default="ACTIVE", description="ACTIVE or RESOLVED.")
-    stage: Optional[str] = Field(
-        default=None, description="TRIAGE, INVESTIGATION, WORK_IN_PROGRESS, FIXED, or NO_ACTION_REQUIRED."
+    stage: str | None = Field(
+        default=None,
+        description="TRIAGE, INVESTIGATION, WORK_IN_PROGRESS, FIXED, or NO_ACTION_REQUIRED.",
     )
-    message: Optional[str] = None
+    message: str | None = None
 
 
 class IncidentSourceDoc(BaseModel):
     type: str = Field(description="MANUAL or ASSERTION_FAILURE.")
-    sourceUrn: Optional[str] = Field(
-        default=None, description="Full URN of the triggering entity, e.g. an ASSERTION's urn, if type is ASSERTION_FAILURE."
+    sourceUrn: str | None = Field(
+        default=None,
+        description=(
+            "Full URN of the triggering entity, e.g. an ASSERTION's urn, "
+            "if type is ASSERTION_FAILURE."
+        ),
     )
 
 
@@ -590,22 +710,35 @@ class IncidentDoc(HasTags, _AllowExtraFields):
     type: str = Field(
         description="OPERATIONAL, FRESHNESS, VOLUME, SQL, FIELD, DATA_SCHEMA, or CUSTOM."
     )
-    customType: Optional[str] = Field(default=None, description="Free-text type name, required if type is CUSTOM.")
-    title: Optional[str] = None
-    description: Optional[str] = None
-    priority: Optional[int] = None
-    entities: List[str] = Field(description="Full URNs of the entities (usually datasets) affected.")
-    status: Optional[IncidentStatusDoc] = None
-    assignees: Optional[StringList] = Field(
+    customType: str | None = Field(
+        default=None, description="Free-text type name, required if type is CUSTOM."
+    )
+    title: str | None = None
+    description: str | None = None
+    priority: int | None = None
+    entities: list[str] = Field(
+        description="Full URNs of the entities (usually datasets) affected."
+    )
+    status: IncidentStatusDoc | None = None
+    assignees: StringList | None = Field(
         default=None, description="Owner names; converted to corpuser URNs if not already URNs."
     )
-    source: Optional[IncidentSourceDoc] = None
-    startedAt: Optional[int] = Field(default=None, description="Epoch millis.")
-    notes: Optional[StringList] = Field(default=None, description="Free-text notes about this incident.")
+    source: IncidentSourceDoc | None = None
+    startedAt: int | None = Field(default=None, description="Epoch millis.")
+    notes: StringList | None = Field(
+        default=None, description="Free-text notes about this incident."
+    )
 
 
 class DocumentDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasLinks, HasStructuredProps, HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasLinks,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A knowledge-base document (a runbook, a FAQ, an AI-context note, ...).
     `document` permits owners/tags/glossaryTerms/domains/links/
@@ -614,26 +747,40 @@ class DocumentDoc(
     kind: Literal["DOCUMENT"]
     id: str = Field(description="Stable identifier, becomes urn:li:document:<id>.")
     title: str
-    text: Optional[str] = Field(
+    text: str | None = Field(
         default=None,
-        description="Markdown body, stored natively in DataHub. Required unless externalUrl is set.",
+        description=(
+            "Markdown body, stored natively in DataHub. Required unless externalUrl is set."
+        ),
     )
     status: str = Field(default="PUBLISHED", description="PUBLISHED or UNPUBLISHED.")
     showInGlobalContext: bool = Field(
         default=True,
-        description="If false, only reachable via relatedAssets/relatedDocuments -- useful for AI-only context documents.",
+        description=(
+            "If false, only reachable via relatedAssets/relatedDocuments "
+            "-- useful for AI-only context documents."
+        ),
     )
-    platform: Optional[str] = Field(
-        default=None, description="The external system's platform, e.g. 'confluence'. Required if externalUrl is set."
+    platform: str | None = Field(
+        default=None,
+        description=(
+            "The external system's platform, e.g. 'confluence'. Required if externalUrl is set."
+        ),
     )
-    externalUrl: Optional[str] = Field(default=None, description="Link to the document in an external system.")
-    externalId: Optional[str] = None
-    parentDocument: Optional[str] = Field(default=None, description="id of a parent DOCUMENT, for hierarchical organization.")
-    relatedAssets: Optional[List[str]] = Field(
+    externalUrl: str | None = Field(
+        default=None, description="Link to the document in an external system."
+    )
+    externalId: str | None = None
+    parentDocument: str | None = Field(
+        default=None, description="id of a parent DOCUMENT, for hierarchical organization."
+    )
+    relatedAssets: list[str] | None = Field(
         default=None, description="Full URNs of related data assets (datasets, dashboards, ...)."
     )
-    relatedDocuments: Optional[StringList] = Field(default=None, description="ids of related DOCUMENT documents.")
-    properties: Optional[Dict[str, Any]] = None
+    relatedDocuments: StringList | None = Field(
+        default=None, description="ids of related DOCUMENT documents."
+    )
+    properties: dict[str, Any] | None = None
 
 
 class MLFeatureRef(BaseModel):
@@ -656,78 +803,117 @@ class MLModelGroupRef(BaseModel):
     platform: str
     name: str
     env: str = "PROD"
-    instance: Optional[str] = None
+    instance: str | None = None
 
 
 class MLFeatureTableDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A feature store's feature table (e.g. a Feast feature view)."""
 
     kind: Literal["MLFEATURE_TABLE"]
-    name: str = Field(description="Feature table identifier. Becomes part of the mlFeatureTable URN.")
+    name: str = Field(
+        description="Feature table identifier. Becomes part of the mlFeatureTable URN."
+    )
     platform: str = Field(description="The feature store platform, e.g. 'feast'.")
-    description: Optional[str] = None
-    properties: Optional[Dict[str, Any]] = None
-    mlFeatures: Optional[List[MLFeatureRef]] = Field(default=None, description="Features in this table.")
-    mlPrimaryKeys: Optional[List[MLPrimaryKeyRef]] = Field(
+    description: str | None = None
+    properties: dict[str, Any] | None = None
+    mlFeatures: list[MLFeatureRef] | None = Field(
+        default=None, description="Features in this table."
+    )
+    mlPrimaryKeys: list[MLPrimaryKeyRef] | None = Field(
         default=None, description="Primary key(s) of this table."
     )
 
 
 class MLFeatureDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A single feature in a feature store."""
 
     kind: Literal["MLFEATURE"]
-    featureNamespace: str = Field(description="The feature's namespace, usually its feature table's name.")
-    name: str
-    description: Optional[str] = None
-    dataType: Optional[str] = Field(
-        default=None, description="One of DataHub's MLFeatureDataType values, e.g. CONTINUOUS, NOMINAL, TEXT."
+    featureNamespace: str = Field(
+        description="The feature's namespace, usually its feature table's name."
     )
-    properties: Optional[Dict[str, Any]] = None
-    sources: Optional[List[QuerySubjectRef]] = Field(
+    name: str
+    description: str | None = None
+    dataType: str | None = Field(
+        default=None,
+        description="One of DataHub's MLFeatureDataType values, e.g. CONTINUOUS, NOMINAL, TEXT.",
+    )
+    properties: dict[str, Any] | None = None
+    sources: list[QuerySubjectRef] | None = Field(
         default=None, description="Dataset(s)/column(s) this feature is derived from."
     )
 
 
 class MLPrimaryKeyDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A feature table's primary key."""
 
     kind: Literal["MLPRIMARY_KEY"]
     featureNamespace: str
     name: str
-    description: Optional[str] = None
-    dataType: Optional[str] = None
-    properties: Optional[Dict[str, Any]] = None
-    sources: List[QuerySubjectRef] = Field(
+    description: str | None = None
+    dataType: str | None = None
+    properties: dict[str, Any] | None = None
+    sources: list[QuerySubjectRef] = Field(
         description="Dataset(s)/column(s) this primary key is derived from."
     )
 
 
 class MLModelGroupDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A group of related ML model versions (e.g. all versions of one MLflow registered model)."""
 
     kind: Literal["MLMODEL_GROUP"]
     name: str = Field(description="Model group identifier. Becomes part of the mlModelGroup URN.")
     platform: str
-    instance: Optional[str] = None
+    instance: str | None = None
     env: str = "PROD"
-    displayName: Optional[str] = None
-    description: Optional[str] = None
-    externalUrl: Optional[str] = None
-    properties: Optional[Dict[str, Any]] = None
-    container: Optional[ContainerRef] = Field(
+    displayName: str | None = None
+    description: str | None = None
+    externalUrl: str | None = None
+    properties: dict[str, Any] | None = None
+    container: ContainerRef | None = Field(
         default=None, description="The model group's parent container, if any."
     )
 
@@ -735,33 +921,33 @@ class MLModelGroupDoc(
 class IntendedUseDoc(BaseModel):
     """[MLMODEL model card] Intended and out-of-scope uses. Emits the `intendedUse` aspect."""
 
-    primaryUses: Optional[List[str]] = None
-    primaryUsers: Optional[List[str]] = None
-    outOfScopeUses: Optional[List[str]] = None
+    primaryUses: list[str] | None = None
+    primaryUsers: list[str] | None = None
+    outOfScopeUses: list[str] | None = None
 
 
 class CaveatDetailsDoc(BaseModel):
-    needsFurtherTesting: Optional[bool] = None
-    caveatDescription: Optional[str] = None
-    groupsNotRepresented: Optional[List[str]] = None
+    needsFurtherTesting: bool | None = None
+    caveatDescription: str | None = None
+    groupsNotRepresented: list[str] | None = None
 
 
 class EthicalConsiderationsDoc(BaseModel):
     """[MLMODEL model card] Emits the `mlModelEthicalConsiderations` aspect."""
 
-    data: Optional[List[str]] = None
-    humanLife: Optional[List[str]] = None
-    mitigations: Optional[List[str]] = None
-    risksAndHarms: Optional[List[str]] = None
-    useCases: Optional[List[str]] = None
+    data: list[str] | None = None
+    humanLife: list[str] | None = None
+    mitigations: list[str] | None = None
+    risksAndHarms: list[str] | None = None
+    useCases: list[str] | None = None
 
 
 class CaveatsAndRecommendationsDoc(BaseModel):
     """[MLMODEL model card] Emits the `mlModelCaveatsAndRecommendations` aspect."""
 
-    caveats: Optional[CaveatDetailsDoc] = None
-    recommendations: Optional[str] = None
-    idealDatasetCharacteristics: Optional[List[str]] = None
+    caveats: CaveatDetailsDoc | None = None
+    recommendations: str | None = None
+    idealDatasetCharacteristics: list[str] | None = None
 
 
 class MLModelDataDoc(BaseModel):
@@ -769,40 +955,51 @@ class MLModelDataDoc(BaseModel):
     the `mlModelTrainingData`/`mlModelEvaluationData` aspects."""
 
     dataset: DatasetRef
-    motivation: Optional[str] = None
-    preProcessing: Optional[List[str]] = None
+    motivation: str | None = None
+    preProcessing: list[str] | None = None
 
 
 class MLModelFactorDoc(BaseModel):
-    groups: Optional[List[str]] = None
-    instrumentation: Optional[List[str]] = None
-    environment: Optional[List[str]] = None
+    groups: list[str] | None = None
+    instrumentation: list[str] | None = None
+    environment: list[str] | None = None
 
 
 class MLModelFactorPromptsDoc(BaseModel):
     """[MLMODEL model card] Emits the `mlModelFactorPrompts` aspect."""
 
-    relevantFactors: Optional[List[MLModelFactorDoc]] = None
-    evaluationFactors: Optional[List[MLModelFactorDoc]] = None
+    relevantFactors: list[MLModelFactorDoc] | None = None
+    evaluationFactors: list[MLModelFactorDoc] | None = None
 
 
 class MLModelMetricsDoc(BaseModel):
     """[MLMODEL model card] Emits the `mlModelMetrics` aspect."""
 
-    performanceMeasures: Optional[List[str]] = None
-    decisionThreshold: Optional[List[str]] = None
+    performanceMeasures: list[str] | None = None
+    decisionThreshold: list[str] | None = None
 
 
 class MLModelSourceCodeDoc(BaseModel):
     type: str = Field(
-        description="TRAINING_PIPELINE_SOURCE_CODE, EVALUATION_PIPELINE_SOURCE_CODE, or ML_MODEL_SOURCE_CODE."
+        description=(
+            "TRAINING_PIPELINE_SOURCE_CODE, EVALUATION_PIPELINE_SOURCE_CODE, "
+            "or ML_MODEL_SOURCE_CODE."
+        )
     )
     sourceCodeUrl: str
 
 
 class MLModelDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """An ML model version. Its full "model card" is supported: intended use, ethical
     considerations, caveats/recommendations, training/evaluation data, factor prompts,
@@ -815,35 +1012,43 @@ class MLModelDoc(
     kind: Literal["MLMODEL"]
     name: str = Field(description="Model version identifier. Becomes part of the mlModel URN.")
     platform: str
-    instance: Optional[str] = None
+    instance: str | None = None
     env: str = "PROD"
-    displayName: Optional[str] = None
-    description: Optional[str] = None
-    type: Optional[str] = Field(default=None, description="Free-text model type, e.g. 'classification'.")
-    externalUrl: Optional[str] = None
-    properties: Optional[Dict[str, Any]] = None
-    hyperParameters: Optional[Dict[str, Any]] = None
-    modelGroup: Optional[MLModelGroupRef] = Field(default=None, description="The MLMODEL_GROUP this version belongs to.")
-    mlFeatures: Optional[List[MLFeatureRef]] = Field(default=None, description="Features this model consumes.")
-    container: Optional[ContainerRef] = Field(default=None, description="The model's parent container, if any.")
-    intendedUse: Optional[IntendedUseDoc] = None
-    ethicalConsiderations: Optional[EthicalConsiderationsDoc] = None
-    caveatsAndRecommendations: Optional[CaveatsAndRecommendationsDoc] = None
-    trainingData: Optional[List[MLModelDataDoc]] = None
-    evaluationData: Optional[List[MLModelDataDoc]] = None
-    factorPrompts: Optional[MLModelFactorPromptsDoc] = None
-    metrics: Optional[MLModelMetricsDoc] = None
-    sourceCode: Optional[List[MLModelSourceCodeDoc]] = None
+    displayName: str | None = None
+    description: str | None = None
+    type: str | None = Field(
+        default=None, description="Free-text model type, e.g. 'classification'."
+    )
+    externalUrl: str | None = None
+    properties: dict[str, Any] | None = None
+    hyperParameters: dict[str, Any] | None = None
+    modelGroup: MLModelGroupRef | None = Field(
+        default=None, description="The MLMODEL_GROUP this version belongs to."
+    )
+    mlFeatures: list[MLFeatureRef] | None = Field(
+        default=None, description="Features this model consumes."
+    )
+    container: ContainerRef | None = Field(
+        default=None, description="The model's parent container, if any."
+    )
+    intendedUse: IntendedUseDoc | None = None
+    ethicalConsiderations: EthicalConsiderationsDoc | None = None
+    caveatsAndRecommendations: CaveatsAndRecommendationsDoc | None = None
+    trainingData: list[MLModelDataDoc] | None = None
+    evaluationData: list[MLModelDataDoc] | None = None
+    factorPrompts: MLModelFactorPromptsDoc | None = None
+    metrics: MLModelMetricsDoc | None = None
+    sourceCode: list[MLModelSourceCodeDoc] | None = None
 
 
 class AiContextDoc(BaseModel):
     """Freeform AI-consumption hints (synonyms, instructions, examples). Emits the
     `aiContext` aspect. Valid on SEMANTIC_MODEL and METRIC."""
 
-    synonyms: Optional[List[str]] = None
-    instructions: Optional[str] = None
-    examples: Optional[List[str]] = None
-    customInstructions: Optional[str] = None
+    synonyms: list[str] | None = None
+    instructions: str | None = None
+    examples: list[str] | None = None
+    customInstructions: str | None = None
 
 
 class SemanticModelRef(BaseModel):
@@ -863,8 +1068,16 @@ class MetricRef(BaseModel):
 
 
 class SemanticModelDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A semantic-layer model (e.g. a dbt semantic model / Looker explore) -- the entity a
     METRIC is defined against. `relationships` (aliased cross-dataset joins) and
@@ -876,22 +1089,30 @@ class SemanticModelDoc(
     platform: str = Field(description="e.g. 'dbt', 'looker'.")
     path: str = Field(description="Logical path/folder. Part of the semanticModel URN.")
     id: str = Field(description="Identifier. Part of the semanticModel URN.")
-    instance: Optional[str] = None
-    displayName: Optional[str] = None
-    description: Optional[str] = None
-    externalUrl: Optional[str] = None
-    nativeDefinition: Optional[str] = Field(
+    instance: str | None = None
+    displayName: str | None = None
+    description: str | None = None
+    externalUrl: str | None = None
+    nativeDefinition: str | None = Field(
         default=None, description="The model's native source definition, e.g. its dbt YAML/SQL."
     )
-    datasets: Optional[List[DatasetRef]] = Field(
+    datasets: list[DatasetRef] | None = Field(
         default=None, description="Datasets this semantic model is built from."
     )
-    aiContext: Optional[AiContextDoc] = None
+    aiContext: AiContextDoc | None = None
 
 
 class MetricDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A business metric definition (e.g. a dbt metric), always scoped to a
     SEMANTIC_MODEL."""
@@ -900,22 +1121,26 @@ class MetricDoc(
     platform: str
     path: str = Field(description="Logical path/folder. Part of the metric URN.")
     id: str = Field(description="Identifier. Part of the metric URN.")
-    instance: Optional[str] = None
-    semanticModel: SemanticModelRef = Field(description="The SEMANTIC_MODEL this metric is defined against.")
-    displayName: Optional[str] = None
-    description: Optional[str] = None
-    externalUrl: Optional[str] = None
-    expression: Optional[str] = Field(
+    instance: str | None = None
+    semanticModel: SemanticModelRef = Field(
+        description="The SEMANTIC_MODEL this metric is defined against."
+    )
+    displayName: str | None = None
+    description: str | None = None
+    externalUrl: str | None = None
+    expression: str | None = Field(
         default=None, description="The metric's SQL expression, e.g. 'count(x) / count(*)'."
     )
-    derivedFrom: Optional[List[MetricRef]] = Field(
+    derivedFrom: list[MetricRef] | None = Field(
         default=None, description="Other metrics this one is computed from."
     )
-    relatedMetrics: Optional[List[MetricRef]] = Field(default=None, description="Loosely related metrics.")
-    datasetUpstreams: Optional[List[DatasetRef]] = Field(
+    relatedMetrics: list[MetricRef] | None = Field(
+        default=None, description="Loosely related metrics."
+    )
+    datasetUpstreams: list[DatasetRef] | None = Field(
         default=None, description="Datasets this metric reads from directly."
     )
-    aiContext: Optional[AiContextDoc] = None
+    aiContext: AiContextDoc | None = None
 
 
 class MLModelRef(BaseModel):
@@ -924,26 +1149,28 @@ class MLModelRef(BaseModel):
     platform: str
     name: str
     env: str = "PROD"
-    instance: Optional[str] = None
+    instance: str | None = None
 
 
 class McpServerDoc(BaseModel):
     """If a SERVICE is itself an MCP server -- emits the mcpServerProperties aspect."""
 
     url: str
-    transport: Optional[str] = Field(default=None, description="HTTP, SSE, or WEBSOCKET.")
-    timeout: Optional[float] = None
-    customHeaders: Optional[Dict[str, str]] = None
+    transport: str | None = Field(default=None, description="HTTP, SSE, or WEBSOCKET.")
+    timeout: float | None = None
+    customHeaders: dict[str, str] | None = None
 
 
 class ServiceDefinitionDoc(BaseModel):
     """A service's machine-readable interface definition (e.g. an OpenAPI document),
     emits the serviceDefinition aspect."""
 
-    format: str = Field(description="OPENAPI, GRAPHQL_SDL, GRPC_PROTO, ASYNCAPI, JSON_SCHEMA, or OTHER.")
+    format: str = Field(
+        description="OPENAPI, GRAPHQL_SDL, GRPC_PROTO, ASYNCAPI, JSON_SCHEMA, or OTHER."
+    )
     rawSpec: str = Field(description="The raw definition text, e.g. an OpenAPI YAML document.")
-    version: Optional[str] = None
-    externalUrl: Optional[str] = None
+    version: str | None = None
+    externalUrl: str | None = None
 
 
 class RestApiDoc(BaseModel):
@@ -955,41 +1182,52 @@ class ApiSignatureDoc(BaseModel):
     """Only `schemaDefinition` (free text) is exposed -- structured input/output field
     lists are out of scope. See _PLANNING.md, Phase 5C."""
 
-    schemaDefinition: Optional[str] = None
+    schemaDefinition: str | None = None
 
 
 class RepositorySourceDoc(BaseModel):
-    externalUrl: Optional[str] = None
-    externalId: Optional[str] = None
+    externalUrl: str | None = None
+    externalId: str | None = None
 
 
 class SkillSourceRepositoryDoc(BaseModel):
-    repositoryUrn: Optional[str] = Field(
+    repositoryUrn: str | None = Field(
         default=None, description="id of a REPOSITORY document; converted to a repository URN."
     )
-    url: Optional[str] = None
-    path: Optional[str] = None
+    url: str | None = None
+    path: str | None = None
 
 
 class AIAgentSourceDoc(BaseModel):
     type: str = Field(description="SYSTEM, NATIVE, or EXTERNAL.")
-    clonedFrom: Optional[str] = Field(default=None, description="id of another AI_AGENT this one was cloned from.")
+    clonedFrom: str | None = Field(
+        default=None, description="id of another AI_AGENT this one was cloned from."
+    )
 
 
 class AIAgentDependenciesDoc(BaseModel):
-    skills: Optional[StringList] = Field(default=None, description="ids of AGENT_SKILL documents.")
-    tools: Optional[StringList] = Field(
+    skills: StringList | None = Field(default=None, description="ids of AGENT_SKILL documents.")
+    tools: StringList | None = Field(
         default=None, description="ids of API documents this agent invokes as tools."
     )
-    models: Optional[List[MLModelRef]] = Field(default=None, description="MLMODEL entities this agent relies on.")
+    models: list[MLModelRef] | None = Field(
+        default=None, description="MLMODEL entities this agent relies on."
+    )
 
 
 class DisplayPropertiesDoc(BaseModel):
-    colorHex: Optional[str] = None
+    colorHex: str | None = None
 
 
 class RepositoryDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasLinks, HasStructuredProps, HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasLinks,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A source code repository (e.g. a GitLab/GitHub project). `repository`
     permits owners/tags/glossaryTerms/domains/links/structuredProperties/subTypes,
@@ -998,22 +1236,32 @@ class RepositoryDoc(
     kind: Literal["REPOSITORY"]
     id: str = Field(description="Stable identifier, becomes urn:li:repository:<id>.")
     name: str
-    description: Optional[str] = None
-    platform: Optional[str] = Field(
-        default=None, description="e.g. 'gitlab', 'github' -- emits the dataPlatformInstance aspect."
+    description: str | None = None
+    platform: str | None = Field(
+        default=None,
+        description="e.g. 'gitlab', 'github' -- emits the dataPlatformInstance aspect.",
     )
-    instance: Optional[str] = None
-    defaultBranch: Optional[str] = None
-    languages: Optional[StringList] = None
-    license: Optional[str] = None
-    homepageUrl: Optional[str] = None
-    archived: Optional[bool] = None
-    source: Optional[RepositorySourceDoc] = None
-    forkOf: Optional[str] = Field(default=None, description="id of another REPOSITORY this one was forked from.")
+    instance: str | None = None
+    defaultBranch: str | None = None
+    languages: StringList | None = None
+    license: str | None = None
+    homepageUrl: str | None = None
+    archived: bool | None = None
+    source: RepositorySourceDoc | None = None
+    forkOf: str | None = Field(
+        default=None, description="id of another REPOSITORY this one was forked from."
+    )
 
 
 class ApiDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasLinks, HasStructuredProps, HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasLinks,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A callable API (e.g. a REST endpoint). `api` permits owners/tags/
     glossaryTerms/domains/links/structuredProperties/subTypes, but not
@@ -1022,19 +1270,25 @@ class ApiDoc(
     kind: Literal["API"]
     id: str = Field(description="Stable identifier, becomes urn:li:api:<id>.")
     name: str
-    description: Optional[str] = None
-    externalUrl: Optional[str] = None
-    sourceRepository: Optional[str] = Field(default=None, description="id of a REPOSITORY document.")
-    restApi: Optional[RestApiDoc] = None
-    signature: Optional[ApiSignatureDoc] = None
-    platform: Optional[str] = Field(
+    description: str | None = None
+    externalUrl: str | None = None
+    sourceRepository: str | None = Field(default=None, description="id of a REPOSITORY document.")
+    restApi: RestApiDoc | None = None
+    signature: ApiSignatureDoc | None = None
+    platform: str | None = Field(
         default=None, description="e.g. 'kong' -- emits the dataPlatformInstance aspect."
     )
-    instance: Optional[str] = None
+    instance: str | None = None
 
 
 class AgentSkillDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasLinks, HasStructuredProps, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasLinks,
+    HasStructuredProps,
+    _AllowExtraFields,
 ):
     """A reusable capability an AI_AGENT can invoke. `agentSkill` permits
     owners/tags/glossaryTerms/domains/links/structuredProperties, but not
@@ -1043,18 +1297,24 @@ class AgentSkillDoc(
     kind: Literal["AGENT_SKILL"]
     id: str = Field(description="Stable identifier, becomes urn:li:agentSkill:<id>.")
     name: str
-    description: Optional[str] = None
-    instructions: Optional[str] = None
-    requiredTools: Optional[StringList] = Field(
+    description: str | None = None
+    instructions: str | None = None
+    requiredTools: StringList | None = Field(
         default=None, description="ids of API documents this skill requires."
     )
-    sourceRepository: Optional[SkillSourceRepositoryDoc] = None
-    platform: Optional[str] = Field(default=None, description="Emits the dataPlatformInstance aspect.")
-    instance: Optional[str] = None
+    sourceRepository: SkillSourceRepositoryDoc | None = None
+    platform: str | None = Field(default=None, description="Emits the dataPlatformInstance aspect.")
+    instance: str | None = None
 
 
 class AIAgentDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasLinks, HasStructuredProps, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasLinks,
+    HasStructuredProps,
+    _AllowExtraFields,
 ):
     """An AI agent. `aiAgent` permits owners/tags/glossaryTerms/domains/links/
     structuredProperties, but not applications, deprecation, or subTypes."""
@@ -1062,14 +1322,14 @@ class AIAgentDoc(
     kind: Literal["AI_AGENT"]
     id: str = Field(description="Stable identifier, becomes urn:li:aiAgent:<id>.")
     name: str
-    tagline: Optional[str] = None
-    description: Optional[str] = None
-    instructions: Optional[str] = None
-    source: Optional[AIAgentSourceDoc] = None
-    dependencies: Optional[AIAgentDependenciesDoc] = None
-    displayProperties: Optional[DisplayPropertiesDoc] = None
-    platform: Optional[str] = Field(default=None, description="Emits the dataPlatformInstance aspect.")
-    instance: Optional[str] = None
+    tagline: str | None = None
+    description: str | None = None
+    instructions: str | None = None
+    source: AIAgentSourceDoc | None = None
+    dependencies: AIAgentDependenciesDoc | None = None
+    displayProperties: DisplayPropertiesDoc | None = None
+    platform: str | None = Field(default=None, description="Emits the dataPlatformInstance aspect.")
+    instance: str | None = None
 
 
 class ServiceDoc(HasOwners, HasTags, HasSubTypes, _AllowExtraFields):
@@ -1079,20 +1339,32 @@ class ServiceDoc(HasOwners, HasTags, HasSubTypes, _AllowExtraFields):
     kind: Literal["SERVICE"]
     id: str = Field(description="Stable identifier, becomes urn:li:service:<id>.")
     displayName: str
-    description: Optional[str] = None
-    lifecycle: Optional[str] = Field(default=None, description="EXPERIMENTAL, PRODUCTION, or DEPRECATED.")
-    apis: Optional[StringList] = Field(default=None, description="ids of API documents this service exposes.")
-    sourceRepository: Optional[str] = Field(default=None, description="id of a REPOSITORY document.")
-    mcpServer: Optional[McpServerDoc] = None
-    definition: Optional[ServiceDefinitionDoc] = None
-    properties: Optional[Dict[str, Any]] = None
-    platform: Optional[str] = Field(default=None, description="Emits the dataPlatformInstance aspect.")
-    instance: Optional[str] = None
+    description: str | None = None
+    lifecycle: str | None = Field(
+        default=None, description="EXPERIMENTAL, PRODUCTION, or DEPRECATED."
+    )
+    apis: StringList | None = Field(
+        default=None, description="ids of API documents this service exposes."
+    )
+    sourceRepository: str | None = Field(default=None, description="id of a REPOSITORY document.")
+    mcpServer: McpServerDoc | None = None
+    definition: ServiceDefinitionDoc | None = None
+    properties: dict[str, Any] | None = None
+    platform: str | None = Field(default=None, description="Emits the dataPlatformInstance aspect.")
+    instance: str | None = None
 
 
 class DataProductDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A data product: a curated bundle of datasets/jobs presented as a
     single discoverable asset, with its own domain/tags/owners."""
@@ -1100,27 +1372,44 @@ class DataProductDoc(
     kind: Literal["DATA_PRODUCT"]
     id: str = Field(description="Stable identifier, becomes urn:li:dataProduct:<id>.")
     name: str
-    description: Optional[str] = None
-    assets: Optional[List[str]] = Field(
-        default=None, description="Full URNs of the entities (datasets, dataJobs, ...) that make up this product."
+    description: str | None = None
+    assets: list[str] | None = Field(
+        default=None,
+        description=(
+            "Full URNs of the entities (datasets, dataJobs, ...) that make up this product."
+        ),
     )
 
 
 class DataFlowDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
-    HasSubTypes, _AllowExtraFields,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
+    HasSubTypes,
+    _AllowExtraFields,
 ):
     """A pipeline (e.g. an Airflow DAG, a dbt project run)."""
 
     kind: Literal["DATA_FLOW"]
-    orchestrator: str = Field(description="e.g. 'airflow', 'dbt'. Becomes part of the dataFlow URN.")
+    orchestrator: str = Field(
+        description="e.g. 'airflow', 'dbt'. Becomes part of the dataFlow URN."
+    )
     flowId: str
-    cluster: str = Field(default="PROD", description="Deployment/cluster identifier, part of the dataFlow URN.")
+    cluster: str = Field(
+        default="PROD", description="Deployment/cluster identifier, part of the dataFlow URN."
+    )
     name: str
-    description: Optional[str] = None
-    project: Optional[str] = None
-    externalUrl: Optional[str] = None
-    container: Optional[ContainerRef] = Field(default=None, description="The pipeline's parent container, if any.")
+    description: str | None = None
+    project: str | None = None
+    externalUrl: str | None = None
+    container: ContainerRef | None = Field(
+        default=None, description="The pipeline's parent container, if any."
+    )
 
 
 class DataFlowRef(BaseModel):
@@ -1138,7 +1427,14 @@ class DataFlowJobRef(DataFlowRef):
 
 
 class DataJobDoc(
-    HasOwners, HasTags, HasTerms, HasDomain, HasApplications, HasLinks, HasDeprecation, HasStructuredProps,
+    HasOwners,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasApplications,
+    HasLinks,
+    HasDeprecation,
+    HasStructuredProps,
     _AllowExtraFields,
 ):
     """A task within a pipeline (DATA_FLOW).
@@ -1151,32 +1447,44 @@ class DataJobDoc(
 
     kind: Literal["DATA_JOB"]
     jobId: str
-    dataFlow: DataFlowRef = Field(description="Reference to the parent DATA_FLOW this task belongs to.")
-    name: str
-    description: Optional[str] = None
-    type: Optional[str] = Field(default=None, description="The job's subtype, e.g. 'RawCopy', 'Transform'.")
-    externalUrl: Optional[str] = None
-    properties: Optional[Dict[str, Any]] = None
-    container: Optional[ContainerRef] = Field(default=None, description="The job's parent container, if any.")
-    inputDatasets: Optional[List[DatasetRef]] = None
-    outputDatasets: Optional[List[DatasetRef]] = None
-    inputDataJobs: Optional[List[DataFlowJobRef]] = Field(
-        default=None, description="Other DATA_JOBs this one depends on -- job-to-job DAG edges with no dataset in between."
+    dataFlow: DataFlowRef = Field(
+        description="Reference to the parent DATA_FLOW this task belongs to."
     )
-    fineGrainedLineages: Optional[List[FineGrainedLineageDoc]] = Field(
+    name: str
+    description: str | None = None
+    type: str | None = Field(
+        default=None, description="The job's subtype, e.g. 'RawCopy', 'Transform'."
+    )
+    externalUrl: str | None = None
+    properties: dict[str, Any] | None = None
+    container: ContainerRef | None = Field(
+        default=None, description="The job's parent container, if any."
+    )
+    inputDatasets: list[DatasetRef] | None = None
+    outputDatasets: list[DatasetRef] | None = None
+    inputDataJobs: list[DataFlowJobRef] | None = Field(
+        default=None,
+        description=(
+            "Other DATA_JOBs this one depends on -- "
+            "job-to-job DAG edges with no dataset in between."
+        ),
+    )
+    fineGrainedLineages: list[FineGrainedLineageDoc] | None = Field(
         default=None, description="Column-level lineage edges from inputDatasets to outputDatasets."
     )
 
 
 class CreatedDoc(BaseModel):
     timestampMillis: int
-    actor: Optional[str] = Field(default=None, description="Owner name; converted to a corpuser URN if not already one.")
+    actor: str | None = Field(
+        default=None, description="Owner name; converted to a corpuser URN if not already one."
+    )
 
 
 class RunEventDoc(BaseModel):
     status: str = Field(description="e.g. STARTED, COMPLETE, FAILURE.")
     timestampMillis: int
-    attempt: Optional[int] = None
+    attempt: int | None = None
 
 
 class DataProcessInstanceDoc(_AllowExtraFields):
@@ -1189,17 +1497,19 @@ class DataProcessInstanceDoc(_AllowExtraFields):
     id: str = Field(description="Stable identifier, becomes urn:li:dataProcessInstance:<id>.")
     name: str
     type: str = "BATCH_SCHEDULED"
-    externalUrl: Optional[str] = None
+    externalUrl: str | None = None
     created: CreatedDoc
-    parentTemplate: DataFlowJobRef = Field(description="Reference to the DATA_JOB this is a run of.")
-    inputs: Optional[List[DatasetRef]] = None
-    outputs: Optional[List[DatasetRef]] = None
-    runEvents: Optional[Annotated[List[RunEventDoc], BeforeValidator(_coerce_to_list)]] = None
+    parentTemplate: DataFlowJobRef = Field(
+        description="Reference to the DATA_JOB this is a run of."
+    )
+    inputs: list[DatasetRef] | None = None
+    outputs: list[DatasetRef] | None = None
+    runEvents: Annotated[list[RunEventDoc], BeforeValidator(_coerce_to_list)] | None = None
 
 
 class AssertionPropertiesDoc(BaseModel):
     name: str
-    dbt_test: Optional[str] = None
+    dbt_test: str | None = None
 
 
 class SchemaFieldSpecDoc(BaseModel):
@@ -1207,7 +1517,7 @@ class SchemaFieldSpecDoc(BaseModel):
 
     path: str
     type: str = "string"
-    nativeType: Optional[str] = None
+    nativeType: str | None = None
 
 
 class AssertionAssertionDoc(BaseModel):
@@ -1220,44 +1530,85 @@ class AssertionAssertionDoc(BaseModel):
     (`AssertionType.pdl`) in favor of `VOLUME`.
     """
 
-    type: str = Field(description="FRESHNESS, VOLUME, SQL, FIELD, DATA_SCHEMA, or CUSTOM -- selects which fields below apply.")
+    type: str = Field(
+        description=(
+            "FRESHNESS, VOLUME, SQL, FIELD, DATA_SCHEMA, or CUSTOM "
+            "-- selects which fields below apply."
+        )
+    )
     entityUrn: str = Field(description="Full URN of the dataset this assertion checks.")
 
     # FRESHNESS
-    freshnessType: Optional[str] = Field(default=None, description="[FRESHNESS] e.g. DATASET_CHANGE.")
-    scheduleType: Optional[str] = Field(default=None, description="[FRESHNESS] e.g. CRON.")
-    cron: Optional[str] = Field(default=None, description="[FRESHNESS] cron expression, if scheduleType is CRON.")
-    timezone: Optional[str] = Field(default=None, description="[FRESHNESS] IANA timezone for the cron schedule.")
+    freshnessType: str | None = Field(default=None, description="[FRESHNESS] e.g. DATASET_CHANGE.")
+    scheduleType: str | None = Field(default=None, description="[FRESHNESS] e.g. CRON.")
+    cron: str | None = Field(
+        default=None, description="[FRESHNESS] cron expression, if scheduleType is CRON."
+    )
+    timezone: str | None = Field(
+        default=None, description="[FRESHNESS] IANA timezone for the cron schedule."
+    )
 
     # VOLUME
-    volumeType: Optional[str] = Field(
-        default=None, description="[VOLUME] ROW_COUNT_TOTAL or ROW_COUNT_CHANGE -- reuses 'operator'/'value'/'changeType' below."
+    volumeType: str | None = Field(
+        default=None,
+        description=(
+            "[VOLUME] ROW_COUNT_TOTAL or ROW_COUNT_CHANGE -- "
+            "reuses 'operator'/'value'/'changeType' below."
+        ),
     )
 
     # SQL / VOLUME
-    sqlType: Optional[str] = Field(default=None, description="[SQL] e.g. METRIC.")
-    statement: Optional[str] = Field(default=None, description="[SQL] the SQL query to evaluate.")
-    operator: Optional[str] = Field(default=None, description="[SQL/FIELD/VOLUME] e.g. GREATER_THAN, EQUAL_TO, NOT_NULL.")
-    value: Optional[Any] = Field(default=None, description="[SQL/VOLUME] the comparison value for 'operator'.")
-    changeType: Optional[str] = Field(default=None, description="[SQL/VOLUME] e.g. ABSOLUTE, PERCENTAGE.")
+    sqlType: str | None = Field(default=None, description="[SQL] e.g. METRIC.")
+    statement: str | None = Field(default=None, description="[SQL] the SQL query to evaluate.")
+    operator: str | None = Field(
+        default=None, description="[SQL/FIELD/VOLUME] e.g. GREATER_THAN, EQUAL_TO, NOT_NULL."
+    )
+    value: Any | None = Field(
+        default=None, description="[SQL/VOLUME] the comparison value for 'operator'."
+    )
+    changeType: str | None = Field(
+        default=None, description="[SQL/VOLUME] e.g. ABSOLUTE, PERCENTAGE."
+    )
 
     # FIELD
-    fieldType: Optional[str] = Field(default=None, description="[FIELD] FIELD_METRIC or FIELD_VALUES.")
-    fieldPath: Optional[str] = Field(default=None, description="[FIELD] the column this assertion checks.")
-    dataType: Optional[str] = Field(default=None, description="[FIELD] the column's DataHub schema type.")
-    nativeDataType: Optional[str] = Field(default=None, description="[FIELD] the column's native source type.")
-    metric: Optional[str] = Field(default=None, description="[FIELD, FIELD_METRIC] e.g. UNIQUE_PERCENTAGE.")
-    metricOperator: Optional[str] = Field(default=None, description="[FIELD, FIELD_METRIC] comparison operator for 'metric'.")
-    metricValue: Optional[Any] = Field(default=None, description="[FIELD, FIELD_METRIC] the comparison value.")
-    excludeNulls: Optional[bool] = Field(default=None, description="[FIELD, FIELD_VALUES] ignore nulls when checking 'operator'.")
+    fieldType: str | None = Field(default=None, description="[FIELD] FIELD_METRIC or FIELD_VALUES.")
+    fieldPath: str | None = Field(
+        default=None, description="[FIELD] the column this assertion checks."
+    )
+    dataType: str | None = Field(
+        default=None, description="[FIELD] the column's DataHub schema type."
+    )
+    nativeDataType: str | None = Field(
+        default=None, description="[FIELD] the column's native source type."
+    )
+    metric: str | None = Field(
+        default=None, description="[FIELD, FIELD_METRIC] e.g. UNIQUE_PERCENTAGE."
+    )
+    metricOperator: str | None = Field(
+        default=None, description="[FIELD, FIELD_METRIC] comparison operator for 'metric'."
+    )
+    metricValue: Any | None = Field(
+        default=None, description="[FIELD, FIELD_METRIC] the comparison value."
+    )
+    excludeNulls: bool | None = Field(
+        default=None, description="[FIELD, FIELD_VALUES] ignore nulls when checking 'operator'."
+    )
 
     # DATA_SCHEMA
-    schemaFields: Optional[List[SchemaFieldSpecDoc]] = Field(default=None, description="[DATA_SCHEMA] the expected columns.")
-    compatibility: Optional[str] = Field(default=None, description="[DATA_SCHEMA] e.g. EXACT_MATCH, SUPERSET.")
+    schemaFields: list[SchemaFieldSpecDoc] | None = Field(
+        default=None, description="[DATA_SCHEMA] the expected columns."
+    )
+    compatibility: str | None = Field(
+        default=None, description="[DATA_SCHEMA] e.g. EXACT_MATCH, SUPERSET."
+    )
 
     # CUSTOM
-    customType: Optional[str] = Field(default=None, description="[CUSTOM] free-text assertion type name.")
-    logic: Optional[str] = Field(default=None, description="[CUSTOM] free-text description of the custom check's logic.")
+    customType: str | None = Field(
+        default=None, description="[CUSTOM] free-text assertion type name."
+    )
+    logic: str | None = Field(
+        default=None, description="[CUSTOM] free-text description of the custom check's logic."
+    )
 
 
 class AssertionActionDoc(BaseModel):
@@ -1267,21 +1618,23 @@ class AssertionActionDoc(BaseModel):
 class AssertionActionsDoc(BaseModel):
     """Declarative on-failure/on-success actions. Emits the `assertionActions` aspect."""
 
-    onSuccess: Optional[List[AssertionActionDoc]] = None
-    onFailure: Optional[List[AssertionActionDoc]] = None
+    onSuccess: list[AssertionActionDoc] | None = None
+    onFailure: list[AssertionActionDoc] | None = None
 
 
 class AssertionDoc(HasOwners, HasTags, _AllowExtraFields):
-    """A data quality assertion (freshness, volume, SQL-based, field-level, schema, or custom check)."""
+    """A data quality assertion (freshness, volume, SQL-based, field-level, schema, or custom check)."""  # noqa: E501
 
     kind: Literal["ASSERTION"]
     id: str = Field(description="Stable identifier, becomes urn:li:assertion:<id>.")
-    description: Optional[str] = None
+    description: str | None = None
     sourceType: str = "NATIVE"
-    properties: Optional[AssertionPropertiesDoc] = None
+    properties: AssertionPropertiesDoc | None = None
     assertion: AssertionAssertionDoc
-    assertionNote: Optional[str] = Field(default=None, description="Free-text note about this assertion's most recent run.")
-    assertionActions: Optional[AssertionActionsDoc] = None
+    assertionNote: str | None = Field(
+        default=None, description="Free-text note about this assertion's most recent run."
+    )
+    assertionActions: AssertionActionsDoc | None = None
 
 
 class RawAspectDoc(BaseModel):
@@ -1301,10 +1654,10 @@ class RawAspectDoc(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     aspectName: str
-    dataset: Optional[DatasetRef] = None
-    assertionUrn: Optional[str] = None
-    dataProcessInstanceUrn: Optional[str] = None
-    entityUrn: Optional[str] = None
+    dataset: DatasetRef | None = None
+    assertionUrn: str | None = None
+    dataProcessInstanceUrn: str | None = None
+    entityUrn: str | None = None
 
 
 ENTITY_DOC_TYPES_BY_KIND = {
@@ -1341,48 +1694,48 @@ ENTITY_DOC_TYPES_BY_KIND = {
     "ASSERTION": AssertionDoc,
 }
 
-EntityDoc = Union[
-    DataPlatformDoc,
-    TagDoc,
-    GlossaryNodeDoc,
-    GlossaryTermDoc,
-    StructuredPropertyDoc,
-    DomainDoc,
-    ApplicationDoc,
-    ContainerDoc,
-    DatasetDoc,
-    ChartDoc,
-    DashboardDoc,
-    QueryDoc,
-    IncidentDoc,
-    DocumentDoc,
-    MLFeatureTableDoc,
-    MLFeatureDoc,
-    MLPrimaryKeyDoc,
-    MLModelGroupDoc,
-    MLModelDoc,
-    SemanticModelDoc,
-    MetricDoc,
-    RepositoryDoc,
-    ApiDoc,
-    AgentSkillDoc,
-    AIAgentDoc,
-    ServiceDoc,
-    DataProductDoc,
-    DataFlowDoc,
-    DataJobDoc,
-    DataProcessInstanceDoc,
-    AssertionDoc,
-]
+EntityDoc = (
+    DataPlatformDoc
+    | TagDoc
+    | GlossaryNodeDoc
+    | GlossaryTermDoc
+    | StructuredPropertyDoc
+    | DomainDoc
+    | ApplicationDoc
+    | ContainerDoc
+    | DatasetDoc
+    | ChartDoc
+    | DashboardDoc
+    | QueryDoc
+    | IncidentDoc
+    | DocumentDoc
+    | MLFeatureTableDoc
+    | MLFeatureDoc
+    | MLPrimaryKeyDoc
+    | MLModelGroupDoc
+    | MLModelDoc
+    | SemanticModelDoc
+    | MetricDoc
+    | RepositoryDoc
+    | ApiDoc
+    | AgentSkillDoc
+    | AIAgentDoc
+    | ServiceDoc
+    | DataProductDoc
+    | DataFlowDoc
+    | DataJobDoc
+    | DataProcessInstanceDoc
+    | AssertionDoc
+)
 
-ParsedDoc = Union[EntityDoc, RawAspectDoc]
+ParsedDoc = EntityDoc | RawAspectDoc
 
 
 class DocumentParseError(ValueError):
     """Raised when a YAML document doesn't match any known kind/aspectName shape."""
 
 
-def parse_document(raw: Dict[str, Any]) -> ParsedDoc:
+def parse_document(raw: dict[str, Any]) -> ParsedDoc:
     """Dispatch a raw YAML document dict to the correct Pydantic model."""
     if not isinstance(raw, dict):
         raise DocumentParseError(f"Expected a YAML mapping document, got {type(raw)}")
@@ -1392,8 +1745,7 @@ def parse_document(raw: Dict[str, Any]) -> ParsedDoc:
         model_cls = ENTITY_DOC_TYPES_BY_KIND.get(kind)
         if model_cls is None:
             raise DocumentParseError(
-                f"Unknown kind '{kind}'. Supported kinds: "
-                f"{sorted(ENTITY_DOC_TYPES_BY_KIND)}"
+                f"Unknown kind '{kind}'. Supported kinds: {sorted(ENTITY_DOC_TYPES_BY_KIND)}"
             )
         return model_cls.model_validate(raw)
 

--- a/src/datahub_yaml_source/urns.py
+++ b/src/datahub_yaml_source/urns.py
@@ -11,8 +11,6 @@ emit a warning about a dangling reference (e.g. a `tags: [nope]` pointing at
 a tag that was never declared as its own `TAG` document).
 """
 
-from typing import Optional, Set, Tuple, Union
-
 from datahub.emitter.mce_builder import (
     make_data_platform_urn,
     make_dataplatform_instance_urn,
@@ -53,7 +51,6 @@ from datahub.metadata.urns import (
 from datahub_yaml_source.loader import ParsedRepository
 from datahub_yaml_source.models import (
     ChartRef,
-    ContainerDoc,
     ContainerRef,
     DashboardRef,
     DataFlowJobRef,
@@ -72,7 +69,7 @@ def _passthrough_if_urn(value: str, build) -> str:
     return build(value)
 
 
-def dataset_urn(ref: Union[DatasetRef, DatasetFieldRef]) -> str:
+def dataset_urn(ref: DatasetRef | DatasetFieldRef) -> str:
     return make_dataset_urn_with_platform_instance(
         platform=ref.platform,
         name=ref.name,
@@ -208,7 +205,7 @@ def service_urn(service_id: str) -> str:
     return _passthrough_if_urn(service_id, lambda v: ServiceUrn(v).urn())
 
 
-def data_platform_instance_urn(platform_name: str, instance: Optional[str]) -> Optional[str]:
+def data_platform_instance_urn(platform_name: str, instance: str | None) -> str | None:
     if not instance:
         return None
     return make_dataplatform_instance_urn(platform_name, instance)
@@ -256,7 +253,7 @@ def owner_urn(owner: str) -> str:
     return _passthrough_if_urn(owner, make_user_urn)
 
 
-def container_natural_key(ref: ContainerRef) -> Tuple[str, str, Optional[str]]:
+def container_natural_key(ref: ContainerRef) -> tuple[str, str, str | None]:
     """Hashable natural-key tuple identifying a container, for lookups/sorting.
 
     Deliberately excludes `instance` and `env`, mirroring `container_key()`'s
@@ -272,17 +269,15 @@ class ReferenceIndex:
     """Answers "was this reference declared in the repository?" for warnings."""
 
     def __init__(self, repository: ParsedRepository) -> None:
-        self._tag_names: Set[str] = {t.name for t in repository.tags}
-        self._glossary_term_ids: Set[str] = {t.id for t in repository.glossary_terms}
-        self._glossary_node_ids: Set[str] = {n.id for n in repository.glossary_nodes}
-        self._domain_ids: Set[str] = {d.id for d in repository.domains}
-        self._application_ids: Set[str] = {a.id for a in repository.applications}
-        self._structured_property_names: Set[str] = {
+        self._tag_names: set[str] = {t.name for t in repository.tags}
+        self._glossary_term_ids: set[str] = {t.id for t in repository.glossary_terms}
+        self._glossary_node_ids: set[str] = {n.id for n in repository.glossary_nodes}
+        self._domain_ids: set[str] = {d.id for d in repository.domains}
+        self._application_ids: set[str] = {a.id for a in repository.applications}
+        self._structured_property_names: set[str] = {
             p.qualifiedName for p in repository.structured_properties
         }
-        self._container_keys: Set[Tuple] = {
-            container_natural_key(c) for c in repository.containers
-        }
+        self._container_keys: set[tuple] = {container_natural_key(c) for c in repository.containers}
 
     def has_tag(self, name: str) -> bool:
         return name in self._tag_names

--- a/src/datahub_yaml_source/yaml_source.py
+++ b/src/datahub_yaml_source/yaml_source.py
@@ -1,7 +1,8 @@
 import logging
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 from datahub.ingestion.api.common import PipelineContext
@@ -70,7 +71,7 @@ from datahub_yaml_source.yaml_source_report import YamlSourceReport
 logger = logging.getLogger(__name__)
 
 
-def _resolve_aws_connection(aws_connection_config: Optional[Dict[str, Any]]) -> Optional[Any]:
+def _resolve_aws_connection(aws_connection_config: dict[str, Any] | None) -> Any | None:
     """Lazily build an `AwsConnectionConfig` from the config dict, if set.
 
     `AwsConnectionConfig` (datahub.ingestion.source.aws.aws_common) hard-imports
@@ -85,8 +86,7 @@ def _resolve_aws_connection(aws_connection_config: Optional[Dict[str, Any]]) -> 
         from datahub.ingestion.source.aws.aws_common import AwsConnectionConfig
     except ImportError as e:
         raise ImportError(
-            "Reading s3:// paths requires the 's3' extra: "
-            "pip install datahub-yaml-source[s3]"
+            "Reading s3:// paths requires the 's3' extra: pip install datahub-yaml-source[s3]"
         ) from e
     return AwsConnectionConfig.model_validate(aws_connection_config)
 
@@ -100,13 +100,29 @@ def _resolve_aws_connection(aws_connection_config: Optional[Dict[str, Any]]) -> 
 @capability(SourceCapability.LINEAGE_FINE, "Fully declared in YAML via fineGrainedLineages")
 @capability(SourceCapability.OWNERSHIP, "Enabled by default via 'owners' fields")
 @capability(SourceCapability.TAGS, "Enabled by default via TAG documents and 'tags' references")
-@capability(SourceCapability.DOMAINS, "Enabled by default via DOMAIN documents and 'domains' references")
-@capability(SourceCapability.GLOSSARY_TERMS, "Enabled by default via GLOSSARY_TERM documents and 'glossaryTerms' references")
+@capability(
+    SourceCapability.DOMAINS, "Enabled by default via DOMAIN documents and 'domains' references"
+)
+@capability(
+    SourceCapability.GLOSSARY_TERMS,
+    "Enabled by default via GLOSSARY_TERM documents and 'glossaryTerms' references",
+)
 @capability(SourceCapability.DESCRIPTIONS, "Enabled by default via 'description' fields")
-@capability(SourceCapability.PLATFORM_INSTANCE, "Enabled via 'instance' fields on DATASET/CONTAINER")
-@capability(SourceCapability.DATA_PROFILING, "Via 'aspectName: DATASET_PROFILE' raw-aspect passthrough documents")
-@capability(SourceCapability.USAGE_STATS, "Via 'aspectName: DATASET_USAGE_STATISTICS' raw-aspect passthrough documents")
-@capability(SourceCapability.OPERATION_CAPTURE, "Via 'aspectName: OPERATION' raw-aspect passthrough documents")
+@capability(
+    SourceCapability.PLATFORM_INSTANCE, "Enabled via 'instance' fields on DATASET/CONTAINER"
+)
+@capability(
+    SourceCapability.DATA_PROFILING,
+    "Via 'aspectName: DATASET_PROFILE' raw-aspect passthrough documents",
+)
+@capability(
+    SourceCapability.USAGE_STATS,
+    "Via 'aspectName: DATASET_USAGE_STATISTICS' raw-aspect passthrough documents",
+)
+@capability(
+    SourceCapability.OPERATION_CAPTURE,
+    "Via 'aspectName: OPERATION' raw-aspect passthrough documents",
+)
 @capability(SourceCapability.DELETION_DETECTION, "Enabled via stateful ingestion")
 @capability(SourceCapability.TEST_CONNECTION, "Enabled by default")
 class YamlSource(StatefulIngestionSourceBase, TestableSource):
@@ -136,7 +152,7 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
     def get_report(self) -> YamlSourceReport:
         return self.report
 
-    def _resolve_roots(self, checkout_dir: Optional[Path] = None) -> List[str]:
+    def _resolve_roots(self, checkout_dir: Path | None = None) -> list[str]:
         """Resolve every 'path' entry to a root `load_repository()` can scan.
 
         A local-directory entry is checked to exist/be-a-directory here (so a
@@ -146,9 +162,11 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         to check locally, and `load_repository()` reports any listing/read
         problem for them itself, per-URI, via `on_error`.
         """
-        configured_paths = self.config.path if isinstance(self.config.path, list) else [self.config.path]
+        configured_paths = (
+            self.config.path if isinstance(self.config.path, list) else [self.config.path]
+        )
 
-        roots: List[str] = []
+        roots: list[str] = []
         for entry in configured_paths:
             if is_s3_uri(entry) or is_http_uri(entry):
                 roots.append(entry)
@@ -180,7 +198,7 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
 
         return roots
 
-    def _load_repository(self, checkout_dir: Optional[Path] = None) -> ParsedRepository:
+    def _load_repository(self, checkout_dir: Path | None = None) -> ParsedRepository:
         roots = self._resolve_roots(checkout_dir)
         if not roots:
             return ParsedRepository()
@@ -222,14 +240,13 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         if self.report.files_scanned == 0:
             self.report.warning(
                 title="No YAML files found",
-                message="No '*.yml' / '*.yaml' files were found under the configured "
-                "path.",
+                message="No '*.yml' / '*.yaml' files were found under the configured path.",
                 context=str(roots),
             )
 
         return repository
 
-    def _load_repository_maybe_from_git(self) -> Optional[ParsedRepository]:
+    def _load_repository_maybe_from_git(self) -> ParsedRepository | None:
         """Clone `git_info` into a temp dir (if configured) and load the repository.
 
         Unlike a lazy file-by-file scan, `_load_repository` fully reads and
@@ -264,7 +281,9 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
 
         for platform_doc in repository.platforms:
             self.report.platforms_scanned += 1
-            yield from self._safe_build("DATA_PLATFORM", platform_doc.name, build_data_platform, platform_doc)
+            yield from self._safe_build(
+                "DATA_PLATFORM", platform_doc.name, build_data_platform, platform_doc
+            )
 
         for tag_doc in repository.tags:
             self.report.tags_scanned += 1
@@ -290,12 +309,19 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
 
         for domain_doc in topological_sort_domains(repository.domains):
             self.report.domains_scanned += 1
-            yield from self._safe_build("DOMAIN", domain_doc.id, build_domain, domain_doc, index, self.report)
+            yield from self._safe_build(
+                "DOMAIN", domain_doc.id, build_domain, domain_doc, index, self.report
+            )
 
         for application_doc in repository.applications:
             self.report.applications_scanned += 1
             yield from self._safe_build(
-                "APPLICATION", application_doc.id, build_application, application_doc, index, self.report
+                "APPLICATION",
+                application_doc.id,
+                build_application,
+                application_doc,
+                index,
+                self.report,
             )
 
         for container_doc in topological_sort_containers(repository.containers):
@@ -345,27 +371,45 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         for feature_doc in repository.ml_features:
             self.report.ml_features_scanned += 1
             yield from self._safe_build(
-                "MLFEATURE", f"{feature_doc.featureNamespace}.{feature_doc.name}",
-                build_ml_feature, feature_doc, index, self.report
+                "MLFEATURE",
+                f"{feature_doc.featureNamespace}.{feature_doc.name}",
+                build_ml_feature,
+                feature_doc,
+                index,
+                self.report,
             )
 
         for primary_key_doc in repository.ml_primary_keys:
             self.report.ml_primary_keys_scanned += 1
             yield from self._safe_build(
-                "MLPRIMARY_KEY", f"{primary_key_doc.featureNamespace}.{primary_key_doc.name}",
-                build_ml_primary_key, primary_key_doc, index, self.report
+                "MLPRIMARY_KEY",
+                f"{primary_key_doc.featureNamespace}.{primary_key_doc.name}",
+                build_ml_primary_key,
+                primary_key_doc,
+                index,
+                self.report,
             )
 
         for feature_table_doc in repository.ml_feature_tables:
             self.report.ml_feature_tables_scanned += 1
             yield from self._safe_build(
-                "MLFEATURE_TABLE", feature_table_doc.name, build_ml_feature_table, feature_table_doc, index, self.report
+                "MLFEATURE_TABLE",
+                feature_table_doc.name,
+                build_ml_feature_table,
+                feature_table_doc,
+                index,
+                self.report,
             )
 
         for model_group_doc in repository.ml_model_groups:
             self.report.ml_model_groups_scanned += 1
             yield from self._safe_build(
-                "MLMODEL_GROUP", model_group_doc.name, build_ml_model_group, model_group_doc, index, self.report
+                "MLMODEL_GROUP",
+                model_group_doc.name,
+                build_ml_model_group,
+                model_group_doc,
+                index,
+                self.report,
             )
 
         for model_doc in repository.ml_models:
@@ -378,7 +422,12 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         for semantic_model_doc in repository.semantic_models:
             self.report.semantic_models_scanned += 1
             yield from self._safe_build(
-                "SEMANTIC_MODEL", semantic_model_doc.id, build_semantic_model, semantic_model_doc, index, self.report
+                "SEMANTIC_MODEL",
+                semantic_model_doc.id,
+                build_semantic_model,
+                semantic_model_doc,
+                index,
+                self.report,
             )
 
         for metric_doc in repository.metrics:
@@ -392,7 +441,12 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         for repository_doc in repository.repositories:
             self.report.repositories_scanned += 1
             yield from self._safe_build(
-                "REPOSITORY", repository_doc.id, build_repository, repository_doc, index, self.report
+                "REPOSITORY",
+                repository_doc.id,
+                build_repository,
+                repository_doc,
+                index,
+                self.report,
             )
 
         for api_doc in repository.apis:
@@ -402,7 +456,12 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         for agent_skill_doc in repository.agent_skills:
             self.report.agent_skills_scanned += 1
             yield from self._safe_build(
-                "AGENT_SKILL", agent_skill_doc.id, build_agent_skill, agent_skill_doc, index, self.report
+                "AGENT_SKILL",
+                agent_skill_doc.id,
+                build_agent_skill,
+                agent_skill_doc,
+                index,
+                self.report,
             )
 
         for ai_agent_doc in repository.ai_agents:
@@ -449,9 +508,7 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
 
         for raw_doc in repository.raw_aspects:
             self.report.raw_aspects_scanned += 1
-            yield from self._safe_build(
-                "RAW_ASPECT", raw_doc.aspectName, build_raw_aspect, raw_doc
-            )
+            yield from self._safe_build("RAW_ASPECT", raw_doc.aspectName, build_raw_aspect, raw_doc)
 
     def _safe_build(self, kind: str, identifier: str, builder, *args) -> Iterable[MetadataWorkUnit]:
         """Run a builder, converting any failure into a reported warning instead
@@ -510,7 +567,7 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         return test_report
 
     @staticmethod
-    def _check_s3_connectivity(uri: str, config: "YamlSourceConfig") -> List[str]:
+    def _check_s3_connectivity(uri: str, config: "YamlSourceConfig") -> list[str]:
         try:
             aws_connection = _resolve_aws_connection(config.aws_connection)
         except ImportError as e:
@@ -528,7 +585,7 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         return []
 
     @staticmethod
-    def _check_http_connectivity(uri: str, config: "YamlSourceConfig") -> List[str]:
+    def _check_http_connectivity(uri: str, config: "YamlSourceConfig") -> list[str]:
         if has_glob_characters(uri):
             return [f"Glob patterns are not supported for http(s):// URIs: {uri}"]
 

--- a/src/datahub_yaml_source/yaml_source_config.py
+++ b/src/datahub_yaml_source/yaml_source_config.py
@@ -1,8 +1,6 @@
 import logging
 import sys
-from typing import Any, Dict, List, Optional, Union
-
-from pydantic import Field, model_validator
+from typing import Any
 
 from datahub.configuration.git import GitInfo
 from datahub.ingestion.source.aws.s3_util import is_s3_uri
@@ -13,13 +11,14 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
 )
+from pydantic import Field, model_validator
 
 from datahub_yaml_source.loader import is_http_uri
 
 logger = logging.getLogger(__name__)
 
 
-def _https_clone_url(repo: Any) -> Optional[str]:
+def _https_clone_url(repo: Any) -> str | None:
     """Anonymous HTTPS clone URL derived from `repo`, or None if it can't be.
 
     Mirrors the 'org/repo' shorthand from `GitReference.simplify_repo_url`,
@@ -96,7 +95,7 @@ class YamlSourceConfig(StatefulIngestionConfigBase):
     and instance is declared per-entity inside the YAML files themselves.
     """
 
-    path: Optional[Union[str, List[str]]] = Field(
+    path: str | list[str] | None = Field(
         default=None,
         description="One or more locations to scan for '*.yml' / '*.yaml' metadata "
         "files: a local directory (scanned recursively), an 's3://bucket/prefix' "
@@ -112,7 +111,7 @@ class YamlSourceConfig(StatefulIngestionConfigBase):
         "'s3://'/'http(s)://' entries are not allowed together with 'git_info'.",
     )
 
-    aws_connection: Optional[Dict[str, Any]] = Field(
+    aws_connection: dict[str, Any] | None = Field(
         default=None,
         description="AWS credentials/config for reading 's3://' entries in 'path', "
         "in the same shape as other DataHub sources' 'aws_connection' "
@@ -124,14 +123,14 @@ class YamlSourceConfig(StatefulIngestionConfigBase):
         "(`pip install datahub-yaml-source[s3]`).",
     )
 
-    http_connection: Optional[HTTPConnectionConfig] = Field(
+    http_connection: HTTPConnectionConfig | None = Field(
         default=None,
         description="Authentication/TLS options for reading 'http(s)://' entries in "
         "'path' (bearer token or basic auth, TLS certificate verification). Not "
         "required for a public, unauthenticated URL.",
     )
 
-    max_input_file_bytes: Optional[int] = Field(
+    max_input_file_bytes: int | None = Field(
         default=None,
         description="Reject (and skip, reporting a warning) any individual scanned "
         "file larger than this many bytes. Mainly a safety cap for remote "
@@ -140,7 +139,7 @@ class YamlSourceConfig(StatefulIngestionConfigBase):
         "(default) means no limit.",
     )
 
-    git_info: Optional[YamlGitInfo] = Field(
+    git_info: YamlGitInfo | None = Field(
         default=None,
         description="Git repository to shallow-clone before scanning, instead of "
         "reading from an already-checked-out local directory. 'repo' accepts an "
@@ -165,7 +164,7 @@ class YamlSourceConfig(StatefulIngestionConfigBase):
         "instead of a warning.",
     )
 
-    stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = Field(
+    stateful_ingestion: StatefulStaleMetadataRemovalConfig | None = Field(
         default=None,
         description="Stateful ingestion configuration for stale entity removal. "
         "Enable this to automatically soft-delete entities that were removed "
@@ -178,9 +177,7 @@ class YamlSourceConfig(StatefulIngestionConfigBase):
             if self.path is None:
                 self.path = "."
         elif self.path is None:
-            raise ValueError(
-                "'path' is required when 'git_info' is not set."
-            )
+            raise ValueError("'path' is required when 'git_info' is not set.")
         return self
 
     @model_validator(mode="after")
@@ -192,8 +189,7 @@ class YamlSourceConfig(StatefulIngestionConfigBase):
         for entry in entries:
             if is_s3_uri(entry) and self.aws_connection is None:
                 raise ValueError(
-                    f"'aws_connection' is required when 'path' includes an s3:// "
-                    f"entry: {entry}"
+                    f"'aws_connection' is required when 'path' includes an s3:// entry: {entry}"
                 )
             if self.git_info is not None and (is_s3_uri(entry) or is_http_uri(entry)):
                 raise ValueError(

--- a/src/datahub_yaml_source/yaml_source_report.py
+++ b/src/datahub_yaml_source/yaml_source_report.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Optional
 
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalSourceReport,
@@ -10,7 +9,7 @@ from datahub.utilities.lossy_collections import LossyList
 @dataclass
 class YamlSourceReport(StaleEntityRemovalSourceReport):
     files_scanned: int = 0
-    git_checkout: Optional[str] = None
+    git_checkout: str | None = None
 
     platforms_scanned: int = 0
     tags_scanned: int = 0

--- a/tests/integration/yaml_source/test_yaml_source_golden.py
+++ b/tests/integration/yaml_source/test_yaml_source_golden.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.testing import mce_helpers
@@ -35,7 +35,7 @@ def _run_yaml_source_to_file(output_path: Path) -> None:
     pipeline.raise_from_status()
 
 
-def _normalize(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _normalize(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Drop run-specific `systemMetadata` and sort for order-insensitive diffing."""
     normalized = []
     for event in events:

--- a/tests/unit/test_builders_bi.py
+++ b/tests/unit/test_builders_bi.py
@@ -41,7 +41,9 @@ def test_build_chart_emits_chart_info_and_common_aspects():
             "chartUrl": "https://superset.example.org/chart/12",
             "chartType": "BAR",
             "container": {"platform": "superset", "database": "superset_metadata", "env": "PROD"},
-            "inputDatasets": [{"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}],
+            "inputDatasets": [
+                {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}
+            ],
             "tags": ["dashboard"],
             "domains": "d1",
         }
@@ -55,7 +57,11 @@ def test_build_chart_emits_chart_info_and_common_aspects():
     assert "GlobalTagsClass" in aspect_names
     assert "DomainsClass" in aspect_names
 
-    chart_info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "ChartInfoClass")
+    chart_info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "ChartInfoClass"
+    )
     assert chart_info.title == "Patients par mois"
     assert chart_info.chartUrl == "https://superset.example.org/chart/12"
     assert chart_info.inputs == [
@@ -101,7 +107,9 @@ def test_build_dashboard_emits_dashboard_info_with_charts_and_datasets():
             "dashboardUrl": "https://superset.example.org/dashboard/3",
             "charts": [{"platform": "superset", "name": "patients_par_mois"}],
             "dashboards": [{"platform": "superset", "name": "cockpit_global"}],
-            "inputDatasets": [{"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}],
+            "inputDatasets": [
+                {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}
+            ],
             "tags": ["dashboard"],
         }
     )
@@ -110,7 +118,9 @@ def test_build_dashboard_emits_dashboard_info_with_charts_and_datasets():
     assert not report.dangling_references
 
     dashboard_info = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DashboardInfoClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DashboardInfoClass"
     )
     assert dashboard_info.title == "Cockpit patients"
     assert dashboard_info.dashboardUrl == "https://superset.example.org/dashboard/3"

--- a/tests/unit/test_builders_core.py
+++ b/tests/unit/test_builders_core.py
@@ -39,7 +39,9 @@ def _container(name, database, schema=None, parent=None):
 
 
 def test_build_data_platform_emits_data_platform_info():
-    doc = DataPlatformDoc(kind="DATA_PLATFORM", name="pathling", displayName="Pathling", type="OTHERS")
+    doc = DataPlatformDoc(
+        kind="DATA_PLATFORM", name="pathling", displayName="Pathling", type="OTHERS"
+    )
     wus = list(build_data_platform(doc))
     assert len(wus) == 1
     assert wus[0].metadata.entityUrn == "urn:li:dataPlatform:pathling"
@@ -73,17 +75,24 @@ def test_build_domain_with_parent_domain_and_display_properties():
     report = YamlSourceReport()
 
     doc = DomainDoc(
-        kind="DOMAIN", id="child", name="Child", parentDomain="parent",
+        kind="DOMAIN",
+        id="child",
+        name="Child",
+        parentDomain="parent",
         displayProperties={"colorHex": "#00FF00"},
     )
     wus = list(build_domain(doc, index, report))
     assert not report.dangling_references
     props = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DomainPropertiesClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DomainPropertiesClass"
     )
     assert props.parentDomain == "urn:li:domain:parent"
     display = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DisplayPropertiesClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DisplayPropertiesClass"
     )
     assert display.colorHex == "#00FF00"
 
@@ -109,7 +118,9 @@ def test_topological_sort_domains_orders_parent_before_child():
 
 def test_build_container_reports_dangling_domain():
     doc = _container("public", "ehr", schema="public")
-    doc = ContainerDoc.model_validate({**doc.model_dump(by_alias=True), "domains": "does-not-exist"})
+    doc = ContainerDoc.model_validate(
+        {**doc.model_dump(by_alias=True), "domains": "does-not-exist"}
+    )
     repo = ParsedRepository()
     repo.containers.append(doc)
     index = ReferenceIndex(repo)
@@ -137,11 +148,18 @@ def test_build_container_emits_data_platform_instance_when_instance_declared():
     wus = list(build_container(doc, index, report))
     assert container_key(doc).as_urn() == urn_before  # `instance` never affects the URN
 
-    dpi_aspects = [wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DataPlatformInstanceClass"]
+    dpi_aspects = [
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DataPlatformInstanceClass"
+    ]
     assert len(dpi_aspects) == 2
     assert dpi_aspects[0].instance is None  # gen_containers()'s own emission
     assert dpi_aspects[-1].platform == "urn:li:dataPlatform:postgres"
-    assert dpi_aspects[-1].instance == "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,aphp-prod)"
+    assert (
+        dpi_aspects[-1].instance
+        == "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,aphp-prod)"
+    )
 
 
 def test_build_container_does_not_overwrite_data_platform_instance_when_instance_absent():
@@ -152,7 +170,11 @@ def test_build_container_does_not_overwrite_data_platform_instance_when_instance
     report = YamlSourceReport()
 
     wus = list(build_container(doc, index, report))
-    dpi_aspects = [wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DataPlatformInstanceClass"]
+    dpi_aspects = [
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DataPlatformInstanceClass"
+    ]
     assert len(dpi_aspects) == 1  # only gen_containers()'s own emission, no override
     assert dpi_aspects[0].instance is None
 
@@ -188,14 +210,22 @@ def test_build_application_lineage_emits_input_and_output_edges():
             "applicationLineage": {
                 "consumes": [{"api": "fhir-patient-search-api"}],
                 "produces": [
-                    {"dataset": {"platform": "oracle", "name": "or1pro_prescription", "env": "PROD"}}
+                    {
+                        "dataset": {
+                            "platform": "oracle",
+                            "name": "or1pro_prescription",
+                            "env": "PROD",
+                        }
+                    }
                 ],
             },
         }
     )
     wus = list(build_application(doc, index, report))
     lineage = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "ApplicationLineageClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "ApplicationLineageClass"
     )
     assert [e.destinationUrn for e in lineage.inputEdges] == ["urn:li:api:fhir-patient-search-api"]
     assert [e.destinationUrn for e in lineage.outputEdges] == [
@@ -228,7 +258,11 @@ def test_build_application_lineage_edge_requires_exactly_one_of_api_or_dataset()
                 "consumes": [
                     {
                         "api": "fhir-patient-search-api",
-                        "dataset": {"platform": "oracle", "name": "or1pro_prescription", "env": "PROD"},
+                        "dataset": {
+                            "platform": "oracle",
+                            "name": "or1pro_prescription",
+                            "env": "PROD",
+                        },
                     }
                 ]
             },
@@ -259,7 +293,9 @@ def test_build_application_lineage_validation_error_yields_no_partial_work_units
 
 def test_build_glossary_node_and_term_link_parent(monkeypatch):
     repo = ParsedRepository()
-    repo.glossary_nodes.append(GlossaryNodeDoc(kind="GLOSSARY_NODE", id="fhir:Resource", name="FHIR Resource"))
+    repo.glossary_nodes.append(
+        GlossaryNodeDoc(kind="GLOSSARY_NODE", id="fhir:Resource", name="FHIR Resource")
+    )
     index = ReferenceIndex(repo)
     report = YamlSourceReport()
 
@@ -278,7 +314,9 @@ def test_build_glossary_node_and_term_link_parent(monkeypatch):
 
 def test_build_glossary_term_with_related_terms_and_source():
     repo = ParsedRepository()
-    repo.glossary_terms.append(GlossaryTermDoc(kind="GLOSSARY_TERM", id="fhir:Encounter", name="Encounter"))
+    repo.glossary_terms.append(
+        GlossaryTermDoc(kind="GLOSSARY_TERM", id="fhir:Encounter", name="Encounter")
+    )
     index = ReferenceIndex(repo)
     report = YamlSourceReport()
 
@@ -294,7 +332,9 @@ def test_build_glossary_term_with_related_terms_and_source():
     wus = list(build_glossary_term(term_doc, index, report))
     assert not report.dangling_references
     related = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "GlossaryRelatedTermsClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "GlossaryRelatedTermsClass"
     )
     assert related.hasRelatedTerms == ["urn:li:glossaryTerm:fhir:Encounter"]
 
@@ -320,7 +360,9 @@ def test_build_glossary_node_reports_dangling_parent_node():
     index = ReferenceIndex(repo)
     report = YamlSourceReport()
 
-    node_doc = GlossaryNodeDoc(kind="GLOSSARY_NODE", id="child", name="Child", parentNode="does:not:exist")
+    node_doc = GlossaryNodeDoc(
+        kind="GLOSSARY_NODE", id="child", name="Child", parentNode="does:not:exist"
+    )
     list(build_glossary_node(node_doc, index, report))
     assert len(report.dangling_references) == 1
 

--- a/tests/unit/test_builders_dataset.py
+++ b/tests/unit/test_builders_dataset.py
@@ -1,6 +1,13 @@
 from datahub_yaml_source.builders.dataset import build_dataset
 from datahub_yaml_source.loader import ParsedRepository
-from datahub_yaml_source.models import ApplicationDoc, ContainerDoc, DatasetDoc, DomainDoc, GlossaryTermDoc, TagDoc
+from datahub_yaml_source.models import (
+    ApplicationDoc,
+    ContainerDoc,
+    DatasetDoc,
+    DomainDoc,
+    GlossaryTermDoc,
+    TagDoc,
+)
 from datahub_yaml_source.urns import ReferenceIndex
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
@@ -9,8 +16,12 @@ def _repository_with_known_references():
     repo = ParsedRepository()
     repo.tags.append(TagDoc(kind="TAG", name="pii"))
     repo.tags.append(TagDoc(kind="TAG", name="fhir-r4"))
-    repo.glossary_terms.append(GlossaryTermDoc(kind="GLOSSARY_TERM", id="donnees-patient.patient", name="Patient"))
-    repo.domains.append(DomainDoc(kind="DOMAIN", id="3667192a0a19c51419efe99aa865c1ba", name="Identite patient"))
+    repo.glossary_terms.append(
+        GlossaryTermDoc(kind="GLOSSARY_TERM", id="donnees-patient.patient", name="Patient")
+    )
+    repo.domains.append(
+        DomainDoc(kind="DOMAIN", id="3667192a0a19c51419efe99aa865c1ba", name="Identite patient")
+    )
     repo.containers.append(
         ContainerDoc.model_validate(
             {
@@ -35,11 +46,26 @@ def _dataset_doc():
             "platform": "postgres",
             "env": "PROD",
             "description": "Patient data",
-            "container": {"platform": "postgres", "database": "ehr", "schema": "public", "env": "PROD"},
+            "container": {
+                "platform": "postgres",
+                "database": "ehr",
+                "schema": "public",
+                "env": "PROD",
+            },
             "schema": {
                 "fields": [
-                    {"fieldPath": "patient_id", "type": "number", "nativeDataType": "BIGSERIAL", "partOfKey": True},
-                    {"fieldPath": "nom", "type": "string", "nativeDataType": "VARCHAR(255)", "partOfKey": False},
+                    {
+                        "fieldPath": "patient_id",
+                        "type": "number",
+                        "nativeDataType": "BIGSERIAL",
+                        "partOfKey": True,
+                    },
+                    {
+                        "fieldPath": "nom",
+                        "type": "string",
+                        "nativeDataType": "VARCHAR(255)",
+                        "partOfKey": False,
+                    },
                 ],
             },
             "subTypes": ["Table"],
@@ -60,7 +86,10 @@ def test_build_dataset_emits_expected_aspects():
     assert not report.dangling_references
 
     aspects_by_name = {wu.metadata.aspect.__class__.__name__: wu.metadata.aspect for wu in wus}
-    assert wus[0].metadata.entityUrn == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    assert (
+        wus[0].metadata.entityUrn
+        == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    )
 
     schema_metadata = aspects_by_name["SchemaMetadataClass"]
     assert [f.fieldPath for f in schema_metadata.fields] == ["patient_id", "nom"]
@@ -96,11 +125,25 @@ def test_build_dataset_with_foreign_keys_builds_schema_field_urns():
                     {
                         "name": "fk_actes_patient",
                         "sourceFields": [
-                            {"platform": "postgres", "name": "ehr_public_actes", "env": "PROD", "fieldPath": "patient_id"}
+                            {
+                                "platform": "postgres",
+                                "name": "ehr_public_actes",
+                                "env": "PROD",
+                                "fieldPath": "patient_id",
+                            }
                         ],
-                        "foreignDataset": {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"},
+                        "foreignDataset": {
+                            "platform": "postgres",
+                            "name": "ehr_public_patient",
+                            "env": "PROD",
+                        },
                         "foreignFields": [
-                            {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD", "fieldPath": "patient_id"}
+                            {
+                                "platform": "postgres",
+                                "name": "ehr_public_patient",
+                                "env": "PROD",
+                                "fieldPath": "patient_id",
+                            }
                         ],
                     }
                 ],
@@ -110,10 +153,14 @@ def test_build_dataset_with_foreign_keys_builds_schema_field_urns():
 
     wus = list(build_dataset(doc, index, report))
     schema_metadata = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "SchemaMetadataClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "SchemaMetadataClass"
     )
     fk = schema_metadata.foreignKeys[0]
-    assert fk.foreignDataset == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    assert (
+        fk.foreignDataset == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    )
     assert fk.sourceFields[0].endswith(",patient_id)")
 
 
@@ -129,11 +176,29 @@ def test_build_dataset_with_upstream_lineage_and_fine_grained():
             "platform": "dbt",
             "env": "PROD",
             "upstreamLineage": {
-                "upstreams": [{"dataset": {"platform": "duckdb", "name": "warehouse_staging_stg_ehr__diagnostics", "env": "PROD"}}],
+                "upstreams": [
+                    {
+                        "dataset": {
+                            "platform": "duckdb",
+                            "name": "warehouse_staging_stg_ehr__diagnostics",
+                            "env": "PROD",
+                        }
+                    }
+                ],
                 "fineGrainedLineages": [
                     {
-                        "upstream": {"platform": "duckdb", "name": "warehouse_staging_stg_ehr__diagnostics", "env": "PROD", "fieldPath": "diagnostic_id"},
-                        "downstream": {"platform": "dbt", "name": "transform_layer_fhir_condition", "env": "PROD", "fieldPath": "identifier_diag_value"},
+                        "upstream": {
+                            "platform": "duckdb",
+                            "name": "warehouse_staging_stg_ehr__diagnostics",
+                            "env": "PROD",
+                            "fieldPath": "diagnostic_id",
+                        },
+                        "downstream": {
+                            "platform": "dbt",
+                            "name": "transform_layer_fhir_condition",
+                            "env": "PROD",
+                            "fieldPath": "identifier_diag_value",
+                        },
                         "operation": "TRANSFORM",
                         "confidence": 1.0,
                     }
@@ -144,10 +209,15 @@ def test_build_dataset_with_upstream_lineage_and_fine_grained():
 
     wus = list(build_dataset(doc, index, report))
     upstream_lineage = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "UpstreamLineageClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "UpstreamLineageClass"
     )
     assert len(upstream_lineage.upstreams) == 1
-    assert upstream_lineage.upstreams[0].dataset == "urn:li:dataset:(urn:li:dataPlatform:duckdb,warehouse_staging_stg_ehr__diagnostics,PROD)"
+    assert (
+        upstream_lineage.upstreams[0].dataset
+        == "urn:li:dataset:(urn:li:dataPlatform:duckdb,warehouse_staging_stg_ehr__diagnostics,PROD)"
+    )
     assert len(upstream_lineage.fineGrainedLineages) == 1
     fgl = upstream_lineage.fineGrainedLineages[0]
     assert fgl.transformOperation == "TRANSFORM"
@@ -185,7 +255,9 @@ def test_build_dataset_upstream_lineage_handles_constant_operation_without_upstr
 
     wus = list(build_dataset(doc, index, report))
     upstream_lineage = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "UpstreamLineageClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "UpstreamLineageClass"
     )
     fgl = upstream_lineage.fineGrainedLineages[0]
     assert fgl.upstreams == []
@@ -308,7 +380,11 @@ def test_build_dataset_emits_column_level_metadata():
     aspect_names = {wu.metadata.aspect.__class__.__name__ for wu in field_wus}
     assert aspect_names == {"GlobalTagsClass", "GlossaryTermsClass", "DeprecationClass"}
 
-    tags_aspect = next(wu.metadata.aspect for wu in field_wus if wu.metadata.aspect.__class__.__name__ == "GlobalTagsClass")
+    tags_aspect = next(
+        wu.metadata.aspect
+        for wu in field_wus
+        if wu.metadata.aspect.__class__.__name__ == "GlobalTagsClass"
+    )
     assert tags_aspect.tags[0].tag == "urn:li:tag:pii"
 
     # The second column has no common-metadata fields set -- no workunits for it at all.

--- a/tests/unit/test_builders_extended.py
+++ b/tests/unit/test_builders_extended.py
@@ -37,10 +37,16 @@ def test_build_data_product_emits_properties_assets_and_structured_properties():
             }
         )
     )
-    repo.domains.append(DomainDoc(kind="DOMAIN", id="9306fe49bb1f70f491a712ff19b8d972", name="Parcours patient"))
+    repo.domains.append(
+        DomainDoc(kind="DOMAIN", id="9306fe49bb1f70f491a712ff19b8d972", name="Parcours patient")
+    )
     repo.tags.append(TagDoc(kind="TAG", name="aphp:access"))
     repo.glossary_terms.append(
-        GlossaryTermDoc(kind="GLOSSARY_TERM", id="aphp:medico-administrative", name="Donnees medico-administratives")
+        GlossaryTermDoc(
+            kind="GLOSSARY_TERM",
+            id="aphp:medico-administrative",
+            name="Donnees medico-administratives",
+        )
     )
     index = ReferenceIndex(repo)
     report = YamlSourceReport()
@@ -67,13 +73,20 @@ def test_build_data_product_emits_properties_assets_and_structured_properties():
     assert not report.dangling_references
 
     props = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DataProductPropertiesClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DataProductPropertiesClass"
     )
     assert props.name == "Venues et sejours"
-    assert props.assets[0].destinationUrn == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    assert (
+        props.assets[0].destinationUrn
+        == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    )
 
     structured = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "StructuredPropertiesClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "StructuredPropertiesClass"
     )
     assert structured.properties[0].values == ["DAILY"]
 
@@ -110,7 +123,9 @@ def test_build_data_process_instance_emits_run_events_and_io():
                 "jobId": "ehr_patient_to_raw_layer",
             },
             "inputs": [{"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}],
-            "outputs": [{"platform": "duckdb", "name": "warehouse_raw-layer_patient", "env": "PROD"}],
+            "outputs": [
+                {"platform": "duckdb", "name": "warehouse_raw-layer_patient", "env": "PROD"}
+            ],
             "runEvents": [{"status": "STARTED", "timestampMillis": 1779696000000, "attempt": 1}],
         }
     )
@@ -125,7 +140,9 @@ def test_build_data_process_instance_emits_run_events_and_io():
         "DataProcessInstanceRunEventClass",
     }
     relationships = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DataProcessInstanceRelationshipsClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DataProcessInstanceRelationshipsClass"
     )
     assert "ehr_patient_to_raw_layer" in relationships.parentTemplate
 
@@ -136,7 +153,10 @@ def test_build_assertion_freshness():
             "kind": "ASSERTION",
             "id": "ehr-patient-freshness-check-1",
             "sourceType": "NATIVE",
-            "properties": {"name": "ehr_patient freshness", "dbt_test": "dbt_test.ehr_patient_freshness"},
+            "properties": {
+                "name": "ehr_patient freshness",
+                "dbt_test": "dbt_test.ehr_patient_freshness",
+            },
             "assertion": {
                 "type": "FRESHNESS",
                 "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)",
@@ -218,7 +238,10 @@ def test_build_assertion_rejects_unsupported_type():
         {
             "kind": "ASSERTION",
             "id": "id4",
-            "assertion": {"type": "DATASET", "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:x,y,PROD)"},
+            "assertion": {
+                "type": "DATASET",
+                "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:x,y,PROD)",
+            },
         }
     )
     repo = ParsedRepository()
@@ -313,10 +336,16 @@ def test_build_assertion_emits_note_and_actions():
     index = ReferenceIndex(repo)
     report = YamlSourceReport()
     wus = list(build_assertion(doc, index, report))
-    note = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "AssertionNoteClass")
+    note = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "AssertionNoteClass"
+    )
     assert note.content == "Last run failed due to a warehouse outage"
     actions = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "AssertionActionsClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "AssertionActionsClass"
     )
     assert actions.onFailure[0].type == "RAISE_INCIDENT"
 
@@ -356,7 +385,12 @@ def test_build_query_emits_properties_and_subjects():
             "source": "MANUAL",
             "subjects": [
                 {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"},
-                {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD", "fieldPath": "nom"},
+                {
+                    "platform": "postgres",
+                    "name": "ehr_public_patient",
+                    "env": "PROD",
+                    "fieldPath": "nom",
+                },
             ],
             "subTypes": "View query",
         }
@@ -367,15 +401,22 @@ def test_build_query_emits_properties_and_subjects():
     assert wus[0].metadata.entityUrn == "urn:li:query:q_patients_actifs"
 
     props = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "QueryPropertiesClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "QueryPropertiesClass"
     )
     assert props.statement.value == "select * from ehr_public_patient where actif"
     assert props.name == "Patients actifs"
 
     subjects = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "QuerySubjectsClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "QuerySubjectsClass"
     )
-    assert subjects.subjects[0].entity == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    assert (
+        subjects.subjects[0].entity
+        == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    )
     assert subjects.subjects[1].entity == (
         "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD),nom)"
     )
@@ -391,9 +432,7 @@ def test_build_query_without_subjects_emits_no_subjects_aspect():
     index = ReferenceIndex(repo)
     report = YamlSourceReport()
 
-    doc = QueryDoc.model_validate(
-        {"kind": "QUERY", "id": "q1", "statement": "select 1"}
-    )
+    doc = QueryDoc.model_validate({"kind": "QUERY", "id": "q1", "statement": "select 1"})
 
     wus = list(build_query(doc, index, report))
     aspect_names = {wu.metadata.aspect.__class__.__name__ for wu in wus}
@@ -415,9 +454,16 @@ def test_build_incident_emits_info_and_notes():
             "description": "The patient table missed its 08:00 refresh window",
             "priority": 1,
             "entities": ["urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"],
-            "status": {"state": "ACTIVE", "stage": "TRIAGE", "message": "Investigating warehouse outage"},
+            "status": {
+                "state": "ACTIVE",
+                "stage": "TRIAGE",
+                "message": "Investigating warehouse outage",
+            },
             "assignees": ["datahub"],
-            "source": {"type": "ASSERTION_FAILURE", "sourceUrn": "urn:li:assertion:ehr-patient-freshness-check"},
+            "source": {
+                "type": "ASSERTION_FAILURE",
+                "sourceUrn": "urn:li:assertion:ehr-patient-freshness-check",
+            },
             "startedAt": 1830297600000,
             "notes": ["Warehouse outage confirmed at 08:05"],
             "tags": ["pii"],
@@ -428,17 +474,29 @@ def test_build_incident_emits_info_and_notes():
     assert not report.dangling_references
     assert wus[0].metadata.entityUrn == "urn:li:incident:inc-patient-freshness"
 
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "IncidentInfoClass")
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "IncidentInfoClass"
+    )
     assert info.type == "FRESHNESS"
     assert info.title == "Patient table late"
     assert info.status.stage == "TRIAGE"
     assert info.assignees[0].actor == "urn:li:corpuser:datahub"
     assert info.source.sourceUrn == "urn:li:assertion:ehr-patient-freshness-check"
 
-    notes = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "IncidentNotesClass")
+    notes = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "IncidentNotesClass"
+    )
     assert notes.notes[0].message == "Warehouse outage confirmed at 08:05"
 
-    tags = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "GlobalTagsClass")
+    tags = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "GlobalTagsClass"
+    )
     assert tags.tags[0].tag == "urn:li:tag:pii"
 
 
@@ -458,7 +516,11 @@ def test_build_incident_defaults_status_and_reports_dangling_tag():
     )
 
     wus = list(build_incident(doc, index, report))
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "IncidentInfoClass")
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "IncidentInfoClass"
+    )
     assert info.status.state == "ACTIVE"
     assert len(report.dangling_references) == 1
 
@@ -476,10 +538,17 @@ def test_build_document_native_emits_document_info_and_common_aspects():
             "title": "Runbook - reprise de la table patient",
             "text": "## Etapes\n1. Verifier le job",
             "subTypes": "Runbook",
-            "relatedAssets": ["urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"],
+            "relatedAssets": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+            ],
             "tags": ["pii"],
             "owners": {"owner": "datahub", "type": "TECHNICAL_OWNER"},
-            "links": [{"url": "https://wiki.example.org/runbooks/patient", "description": "Runbook source"}],
+            "links": [
+                {
+                    "url": "https://wiki.example.org/runbooks/patient",
+                    "description": "Runbook source",
+                }
+            ],
         }
     )
 
@@ -488,9 +557,19 @@ def test_build_document_native_emits_document_info_and_common_aspects():
     assert wus[0].metadata.entityUrn == "urn:li:document:runbook_patient"
 
     aspect_names = {wu.metadata.aspect.__class__.__name__ for wu in wus}
-    assert {"DocumentInfoClass", "SubTypesClass", "GlobalTagsClass", "OwnershipClass", "InstitutionalMemoryClass"} <= aspect_names
+    assert {
+        "DocumentInfoClass",
+        "SubTypesClass",
+        "GlobalTagsClass",
+        "OwnershipClass",
+        "InstitutionalMemoryClass",
+    } <= aspect_names
 
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DocumentInfoClass")
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DocumentInfoClass"
+    )
     assert info.title == "Runbook - reprise de la table patient"
     assert info.contents.text == "## Etapes\n1. Verifier le job"
     assert info.source.sourceType == "NATIVE"
@@ -537,7 +616,11 @@ def test_build_document_external_emits_external_source():
     )
 
     wus = list(build_document(doc, index, report))
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DocumentInfoClass")
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DocumentInfoClass"
+    )
     assert info.source.sourceType == "EXTERNAL"
     assert info.source.externalUrl == "https://wiki.example.org/runbooks/patient"
     assert info.source.externalId == "12345"
@@ -560,7 +643,11 @@ def test_build_document_resolves_parent_and_related_documents():
     )
 
     wus = list(build_document(doc, index, report))
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DocumentInfoClass")
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DocumentInfoClass"
+    )
     assert info.parentDocument.document == "urn:li:document:runbook_patient"
     assert info.relatedDocuments[0].document == "urn:li:document:runbook_encounter"
 
@@ -599,7 +686,10 @@ def test_build_raw_aspect_dataset_profile():
         }
     )
     wus = list(build_raw_aspect(doc))
-    assert wus[0].metadata.entityUrn == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    assert (
+        wus[0].metadata.entityUrn
+        == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    )
     aspect = wus[0].metadata.aspect
     assert aspect.rowCount == 1480100
     assert aspect.fieldProfiles[0].distinctValueFrequencies[0].value == "m"
@@ -607,7 +697,10 @@ def test_build_raw_aspect_dataset_profile():
 
 def test_build_raw_aspect_rejects_unsupported_aspect_name():
     doc = RawAspectDoc.model_validate(
-        {"aspectName": "SOME_UNKNOWN_ASPECT", "dataset": {"platform": "x", "name": "y", "env": "PROD"}}
+        {
+            "aspectName": "SOME_UNKNOWN_ASPECT",
+            "dataset": {"platform": "x", "name": "y", "env": "PROD"},
+        }
     )
     with pytest.raises(ValueError, match="Unsupported raw aspectName"):
         list(build_raw_aspect(doc))
@@ -631,7 +724,9 @@ def test_build_raw_aspect_operation_uses_dataset_reference():
             "sourceType": "DATA_PROCESS",
             "numAffectedRows": 982400,
             "actor": "quality-bot",
-            "affectedDatasets": [{"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}],
+            "affectedDatasets": [
+                {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}
+            ],
             "customProperties": {"checkType": "completeness"},
         }
     )

--- a/tests/unit/test_builders_flow_job.py
+++ b/tests/unit/test_builders_flow_job.py
@@ -26,11 +26,15 @@ def test_build_data_flow_emits_expected_urn_and_properties():
     wus = list(build_data_flow(doc, index, report))
     assert wus[0].metadata.entityUrn == "urn:li:dataFlow:(airflow,ehr_to_duckdb_raw_layer,PROD)"
     info = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DataFlowInfoClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DataFlowInfoClass"
     )
     assert info.name == "EHR to duckDB Raw Layer"
     ownership = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "OwnershipClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "OwnershipClass"
     )
     assert len(ownership.owners) == 2
 
@@ -45,16 +49,34 @@ def test_build_data_job_links_to_flow_and_datasets():
         {
             "kind": "DATA_JOB",
             "jobId": "ehr_patient_to_raw_layer",
-            "dataFlow": {"orchestrator": "airflow", "flowId": "ehr_to_duckdb_raw_layer", "cluster": "PROD"},
+            "dataFlow": {
+                "orchestrator": "airflow",
+                "flowId": "ehr_to_duckdb_raw_layer",
+                "cluster": "PROD",
+            },
             "name": "EHR Patient -> DuckDB raw-layer patient",
             "type": "RawCopy",
             "tags": ["pmsi"],
-            "inputDatasets": [{"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}],
-            "outputDatasets": [{"platform": "duckdb", "name": "warehouse_raw-layer_patient", "env": "PROD"}],
+            "inputDatasets": [
+                {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}
+            ],
+            "outputDatasets": [
+                {"platform": "duckdb", "name": "warehouse_raw-layer_patient", "env": "PROD"}
+            ],
             "fineGrainedLineages": [
                 {
-                    "upstream": {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD", "fieldPath": "patient_id"},
-                    "downstream": {"platform": "duckdb", "name": "warehouse_raw-layer_patient", "env": "PROD", "fieldPath": "patient_id"},
+                    "upstream": {
+                        "platform": "postgres",
+                        "name": "ehr_public_patient",
+                        "env": "PROD",
+                        "fieldPath": "patient_id",
+                    },
+                    "downstream": {
+                        "platform": "duckdb",
+                        "name": "warehouse_raw-layer_patient",
+                        "env": "PROD",
+                        "fieldPath": "patient_id",
+                    },
                     "operation": "IDENTITY",
                 }
             ],
@@ -69,7 +91,9 @@ def test_build_data_job_links_to_flow_and_datasets():
     assert "ehr_patient_to_raw_layer" in entity_urn
 
     io_aspect = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DataJobInputOutputClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DataJobInputOutputClass"
     )
     assert io_aspect.inputDatasets == [
         "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
@@ -92,14 +116,21 @@ def test_build_data_job_sets_input_data_jobs():
             "dataFlow": {"orchestrator": "airflow", "flowId": "f1", "cluster": "PROD"},
             "name": "Quality check",
             "inputDataJobs": [
-                {"orchestrator": "airflow", "flowId": "f1", "cluster": "PROD", "jobId": "upstream_job"}
+                {
+                    "orchestrator": "airflow",
+                    "flowId": "f1",
+                    "cluster": "PROD",
+                    "jobId": "upstream_job",
+                }
             ],
         }
     )
 
     wus = list(build_data_job(doc, index, report))
     io_aspect = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DataJobInputOutputClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DataJobInputOutputClass"
     )
     assert io_aspect.inputDatajobs == [
         "urn:li:dataJob:(urn:li:dataFlow:(airflow,f1,PROD),upstream_job)"
@@ -137,7 +168,9 @@ def test_build_data_flow_with_container(monkeypatch):
     wus = list(build_data_flow(doc, index, report))
     assert not report.dangling_references
     container_aspect = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "ContainerClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "ContainerClass"
     )
     assert container_aspect.container is not None
 

--- a/tests/unit/test_builders_ml.py
+++ b/tests/unit/test_builders_ml.py
@@ -28,7 +28,13 @@ def _repo_with_known_refs() -> ParsedRepository:
     repo.tags.append(TagDoc(kind="TAG", name="pii"))
     repo.containers.append(
         ContainerDoc.model_validate(
-            {"kind": "CONTAINER", "platform": "mlflow", "database": "models", "env": "PROD", "name": "Models"}
+            {
+                "kind": "CONTAINER",
+                "platform": "mlflow",
+                "database": "models",
+                "env": "PROD",
+                "name": "Models",
+            }
         )
     )
     return repo
@@ -46,7 +52,14 @@ def test_build_ml_feature_emits_properties_and_sources():
             "name": "age_at_admission",
             "description": "Age at admission",
             "dataType": "CONTINUOUS",
-            "sources": [{"platform": "postgres", "name": "ehr_public_patient", "env": "PROD", "fieldPath": "date_naissance"}],
+            "sources": [
+                {
+                    "platform": "postgres",
+                    "name": "ehr_public_patient",
+                    "env": "PROD",
+                    "fieldPath": "date_naissance",
+                }
+            ],
             "tags": ["pii"],
         }
     )
@@ -55,7 +68,11 @@ def test_build_ml_feature_emits_properties_and_sources():
     assert not report.dangling_references
     assert wus[0].metadata.entityUrn == "urn:li:mlFeature:(patient_features,age_at_admission)"
 
-    props = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "MLFeaturePropertiesClass")
+    props = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "MLFeaturePropertiesClass"
+    )
     assert props.dataType == "CONTINUOUS"
     assert props.sources == [
         "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD),date_naissance)"
@@ -79,8 +96,14 @@ def test_build_ml_primary_key_requires_sources_and_supports_dataset_level_source
 
     wus = list(build_ml_primary_key(doc, index, report))
     assert wus[0].metadata.entityUrn == "urn:li:mlPrimaryKey:(patient_features,patient_id)"
-    props = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "MLPrimaryKeyPropertiesClass")
-    assert props.sources == ["urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"]
+    props = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "MLPrimaryKeyPropertiesClass"
+    )
+    assert props.sources == [
+        "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    ]
 
 
 def test_build_ml_feature_table_resolves_feature_and_primary_key_urns():
@@ -99,9 +122,14 @@ def test_build_ml_feature_table_resolves_feature_and_primary_key_urns():
     )
 
     wus = list(build_ml_feature_table(doc, index, report))
-    assert wus[0].metadata.entityUrn == "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,patient_features)"
+    assert (
+        wus[0].metadata.entityUrn
+        == "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,patient_features)"
+    )
     props = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "MLFeatureTablePropertiesClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "MLFeatureTablePropertiesClass"
     )
     assert props.mlFeatures == ["urn:li:mlFeature:(patient_features,age_at_admission)"]
     assert props.mlPrimaryKeys == ["urn:li:mlPrimaryKey:(patient_features,patient_id)"]
@@ -122,7 +150,10 @@ def test_build_ml_model_group_reports_dangling_container():
     )
 
     wus = list(build_ml_model_group(doc, index, report))
-    assert wus[0].metadata.entityUrn == "urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,readmission_risk,PROD)"
+    assert (
+        wus[0].metadata.entityUrn
+        == "urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,readmission_risk,PROD)"
+    )
     assert len(report.dangling_references) == 1
     assert any(wu.metadata.aspect.__class__.__name__ == "ContainerClass" for wu in wus)
 
@@ -143,39 +174,83 @@ def test_build_ml_model_emits_model_card_and_hyperparameters():
             "modelGroup": {"platform": "mlflow", "name": "readmission_risk", "env": "PROD"},
             "mlFeatures": [{"featureNamespace": "patient_features", "name": "age_at_admission"}],
             "container": {"platform": "mlflow", "database": "models", "env": "PROD"},
-            "intendedUse": {"primaryUses": ["Prioritize follow-up"], "outOfScopeUses": ["Automated clinical decisions"]},
-            "ethicalConsiderations": {"risksAndHarms": ["Possible bias on under-represented groups"]},
+            "intendedUse": {
+                "primaryUses": ["Prioritize follow-up"],
+                "outOfScopeUses": ["Automated clinical decisions"],
+            },
+            "ethicalConsiderations": {
+                "risksAndHarms": ["Possible bias on under-represented groups"]
+            },
             "caveatsAndRecommendations": {
                 "caveats": {"needsFurtherTesting": True},
                 "recommendations": "Do not use without clinical oversight",
             },
-            "trainingData": [{"dataset": {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}, "motivation": "cohort"}],
-            "evaluationData": [{"dataset": {"platform": "postgres", "name": "ehr_public_patient_holdout", "env": "PROD"}}],
+            "trainingData": [
+                {
+                    "dataset": {
+                        "platform": "postgres",
+                        "name": "ehr_public_patient",
+                        "env": "PROD",
+                    },
+                    "motivation": "cohort",
+                }
+            ],
+            "evaluationData": [
+                {
+                    "dataset": {
+                        "platform": "postgres",
+                        "name": "ehr_public_patient_holdout",
+                        "env": "PROD",
+                    }
+                }
+            ],
             "factorPrompts": {"relevantFactors": [{"groups": ["Age > 75"]}]},
             "metrics": {"performanceMeasures": ["AUC 0.82"]},
-            "sourceCode": [{"type": "ML_MODEL_SOURCE_CODE", "sourceCodeUrl": "https://gitlab.example.org/model"}],
+            "sourceCode": [
+                {
+                    "type": "ML_MODEL_SOURCE_CODE",
+                    "sourceCodeUrl": "https://gitlab.example.org/model",
+                }
+            ],
             "tags": ["pii"],
         }
     )
 
     wus = list(build_ml_model(doc, index, report))
     assert not report.dangling_references
-    assert wus[0].metadata.entityUrn == "urn:li:mlModel:(urn:li:dataPlatform:mlflow,readmission_risk_v3,PROD)"
+    assert (
+        wus[0].metadata.entityUrn
+        == "urn:li:mlModel:(urn:li:dataPlatform:mlflow,readmission_risk_v3,PROD)"
+    )
 
     aspect_names = {wu.metadata.aspect.__class__.__name__ for wu in wus}
     assert {
-        "MLModelPropertiesClass", "ContainerClass", "IntendedUseClass", "EthicalConsiderationsClass",
-        "CaveatsAndRecommendationsClass", "TrainingDataClass", "EvaluationDataClass",
-        "MLModelFactorPromptsClass", "MetricsClass", "SourceCodeClass", "GlobalTagsClass",
+        "MLModelPropertiesClass",
+        "ContainerClass",
+        "IntendedUseClass",
+        "EthicalConsiderationsClass",
+        "CaveatsAndRecommendationsClass",
+        "TrainingDataClass",
+        "EvaluationDataClass",
+        "MLModelFactorPromptsClass",
+        "MetricsClass",
+        "SourceCodeClass",
+        "GlobalTagsClass",
     } <= aspect_names
 
-    props = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "MLModelPropertiesClass")
+    props = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "MLModelPropertiesClass"
+    )
     assert props.type == "classification"
     assert props.hyperParameters == {"n_estimators": 200, "max_depth": 8}
     assert props.mlFeatures == ["urn:li:mlFeature:(patient_features,age_at_admission)"]
 
     caveats = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "CaveatsAndRecommendationsClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "CaveatsAndRecommendationsClass"
     )
     assert caveats.caveats.needsFurtherTesting is True
     assert caveats.recommendations == "Do not use without clinical oversight"
@@ -215,5 +290,9 @@ def test_build_ml_model_uses_native_model_group_reference():
     )
 
     wus = list(build_ml_model(doc, index, report))
-    props = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "MLModelPropertiesClass")
+    props = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "MLModelPropertiesClass"
+    )
     assert props.groups == ["urn:li:mlModelGroup:(urn:li:dataPlatform:mlflow,g,PROD)"]

--- a/tests/unit/test_builders_semantic.py
+++ b/tests/unit/test_builders_semantic.py
@@ -36,14 +36,27 @@ def test_build_semantic_model_emits_info_and_ai_context():
 
     wus = list(build_semantic_model(doc, index, report))
     assert not report.dangling_references
-    assert wus[0].metadata.entityUrn == "urn:li:semanticModel:(urn:li:dataPlatform:dbt,models/marts,patients_actifs)"
+    assert (
+        wus[0].metadata.entityUrn
+        == "urn:li:semanticModel:(urn:li:dataPlatform:dbt,models/marts,patients_actifs)"
+    )
 
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "SemanticModelInfoClass")
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "SemanticModelInfoClass"
+    )
     assert info.name == "Patients actifs"
     assert info.externalUrl == "https://dbt.example.org/marts/patients_actifs"
-    assert info.datasets == ["urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"]
+    assert info.datasets == [
+        "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    ]
 
-    ai_context = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "AiContextClass")
+    ai_context = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "AiContextClass"
+    )
     assert ai_context.synonyms == ["active cohort"]
 
     assert any(wu.metadata.aspect.__class__.__name__ == "GlobalTagsClass" for wu in wus)
@@ -64,20 +77,36 @@ def test_build_metric_requires_semantic_model_and_emits_upstreams_and_relationsh
             "semanticModel": {"platform": "dbt", "path": "models/marts", "id": "patients_actifs"},
             "expression": "count(readmission_30j) / count(*)",
             "derivedFrom": [{"platform": "dbt", "path": "models/marts", "id": "base_metric"}],
-            "relatedMetrics": [{"platform": "dbt", "path": "models/marts", "id": "taux_readmission_90j"}],
-            "datasetUpstreams": [{"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}],
+            "relatedMetrics": [
+                {"platform": "dbt", "path": "models/marts", "id": "taux_readmission_90j"}
+            ],
+            "datasetUpstreams": [
+                {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}
+            ],
         }
     )
 
     wus = list(build_metric(doc, index, report))
-    assert wus[0].metadata.entityUrn == "urn:li:metric:(urn:li:dataPlatform:dbt,models/marts,taux_readmission_30j)"
+    assert (
+        wus[0].metadata.entityUrn
+        == "urn:li:metric:(urn:li:dataPlatform:dbt,models/marts,taux_readmission_30j)"
+    )
 
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "MetricInfoClass")
-    assert info.semanticModel == "urn:li:semanticModel:(urn:li:dataPlatform:dbt,models/marts,patients_actifs)"
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "MetricInfoClass"
+    )
+    assert (
+        info.semanticModel
+        == "urn:li:semanticModel:(urn:li:dataPlatform:dbt,models/marts,patients_actifs)"
+    )
     assert info.expression.dialects[0].expression == "count(readmission_30j) / count(*)"
 
     relationships = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "MetricRelationshipsClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "MetricRelationshipsClass"
     )
     assert [e.destinationUrn for e in relationships.derivedFrom] == [
         "urn:li:metric:(urn:li:dataPlatform:dbt,models/marts,base_metric)"
@@ -87,7 +116,9 @@ def test_build_metric_requires_semantic_model_and_emits_upstreams_and_relationsh
     ]
 
     upstreams = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "MetricUpstreamsClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "MetricUpstreamsClass"
     )
     assert [e.destinationUrn for e in upstreams.datasetUpstreams] == [
         "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"

--- a/tests/unit/test_builders_software.py
+++ b/tests/unit/test_builders_software.py
@@ -9,7 +9,14 @@ from datahub_yaml_source.builders.software import (
     build_service,
 )
 from datahub_yaml_source.loader import ParsedRepository
-from datahub_yaml_source.models import AgentSkillDoc, AIAgentDoc, ApiDoc, RepositoryDoc, ServiceDoc, TagDoc
+from datahub_yaml_source.models import (
+    AgentSkillDoc,
+    AIAgentDoc,
+    ApiDoc,
+    RepositoryDoc,
+    ServiceDoc,
+    TagDoc,
+)
 from datahub_yaml_source.urns import ReferenceIndex
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
@@ -33,7 +40,10 @@ def test_build_repository_emits_properties_source_lineage_and_platform_instance(
             "defaultBranch": "main",
             "languages": ["Java"],
             "license": "Apache-2.0",
-            "source": {"externalUrl": "https://gitlab.example.org/ds/pathling", "externalId": "1234"},
+            "source": {
+                "externalUrl": "https://gitlab.example.org/ds/pathling",
+                "externalId": "1234",
+            },
             "forkOf": "upstream-pathling",
             "platform": "gitlab",
             "instance": "aphp-prod",
@@ -45,17 +55,33 @@ def test_build_repository_emits_properties_source_lineage_and_platform_instance(
     assert not report.dangling_references
     assert wus[0].metadata.entityUrn == "urn:li:repository:aphp-pathling"
 
-    props = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "RepositoryPropertiesClass")
+    props = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "RepositoryPropertiesClass"
+    )
     assert props.name == "aphp/pathling"
     assert props.defaultBranch == "main"
 
-    source = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "RepositorySourceClass")
+    source = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "RepositorySourceClass"
+    )
     assert source.externalId == "1234"
 
-    lineage = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "RepositoryLineageClass")
+    lineage = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "RepositoryLineageClass"
+    )
     assert lineage.forkOf == "urn:li:repository:upstream-pathling"
 
-    dpi = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DataPlatformInstanceClass")
+    dpi = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DataPlatformInstanceClass"
+    )
     assert dpi.platform == "urn:li:dataPlatform:gitlab"
     assert dpi.instance == "urn:li:dataPlatformInstance:(urn:li:dataPlatform:gitlab,aphp-prod)"
 
@@ -81,14 +107,26 @@ def test_build_api_resolves_source_repository_and_emits_rest_and_signature():
     wus = list(build_api(doc, index, report))
     assert wus[0].metadata.entityUrn == "urn:li:api:fhir-patient-search-api"
 
-    props = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "ApiPropertiesClass")
+    props = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "ApiPropertiesClass"
+    )
     assert props.sourceRepository == "urn:li:repository:aphp-pathling"
 
-    rest = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "RestApiPropertiesClass")
+    rest = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "RestApiPropertiesClass"
+    )
     assert rest.method == "GET"
     assert rest.path == "/Patient"
 
-    signature = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "ApiSignatureClass")
+    signature = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "ApiSignatureClass"
+    )
     assert signature.schemaDefinition == "OpenAPI 3.0"
 
 
@@ -110,7 +148,11 @@ def test_build_agent_skill_resolves_source_repository_urn():
     wus = list(build_agent_skill(doc, index, report))
     assert wus[0].metadata.entityUrn == "urn:li:agentSkill:fhir-query-skill"
 
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "AgentSkillInfoClass")
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "AgentSkillInfoClass"
+    )
     assert info.requiredTools == ["urn:li:api:fhir-patient-search-api"]
     assert info.sourceRepository.repositoryUrn == "urn:li:repository:aphp-pathling"
     assert info.sourceRepository.path == "skills/fhir_query"
@@ -139,17 +181,29 @@ def test_build_ai_agent_emits_deterministic_audit_stamp_and_dependencies():
     wus = list(build_ai_agent(doc, index, report))
     assert wus[0].metadata.entityUrn == "urn:li:aiAgent:cohort-builder-agent"
 
-    info = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "AIAgentInfoClass")
+    info = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "AIAgentInfoClass"
+    )
     assert info.created.time == 0
     assert info.lastModified.time == 0
     assert info.source.type == "NATIVE"
 
-    deps = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "AIAgentDependenciesClass")
+    deps = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "AIAgentDependenciesClass"
+    )
     assert deps.skills == ["urn:li:agentSkill:fhir-query-skill"]
     assert deps.models == ["urn:li:mlModel:(urn:li:dataPlatform:mlflow,readmission_risk_v3,PROD)"]
     assert deps.tools == ["urn:li:api:fhir-patient-search-api"]
 
-    display = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "DisplayPropertiesClass")
+    display = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "DisplayPropertiesClass"
+    )
     assert display.colorHex == "#2E86AB"
 
 
@@ -181,7 +235,11 @@ def test_build_service_only_permits_tags_owners_subtypes_and_wraps_raw_spec():
     wus = list(build_service(doc, index, report))
     assert wus[0].metadata.entityUrn == "urn:li:service:pathling-fhir-server"
 
-    props = next(wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "ServicePropertiesClass")
+    props = next(
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "ServicePropertiesClass"
+    )
     assert props.apis == ["urn:li:api:fhir-patient-search-api"]
     assert props.sourceRepository == "urn:li:repository:aphp-pathling"
     assert props.lifecycle == "PRODUCTION"
@@ -189,12 +247,16 @@ def test_build_service_only_permits_tags_owners_subtypes_and_wraps_raw_spec():
     assert props.customProperties == {"cluster": "eds", "replicas": "3"}
 
     mcp_server = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "McpServerPropertiesClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "McpServerPropertiesClass"
     )
     assert mcp_server.url == "https://mcp.example.org/pathling"
 
     definition = next(
-        wu.metadata.aspect for wu in wus if wu.metadata.aspect.__class__.__name__ == "ServiceDefinitionClass"
+        wu.metadata.aspect
+        for wu in wus
+        if wu.metadata.aspect.__class__.__name__ == "ServiceDefinitionClass"
     )
     assert definition.rawSpec.blob == "openapi: 3.0.0"
 

--- a/tests/unit/test_json_schema_generation.py
+++ b/tests/unit/test_json_schema_generation.py
@@ -45,7 +45,9 @@ def test_generated_schema_validates_every_fixture_document():
                 continue
             checked += 1
             errors = list(validator.iter_errors(doc))
-            assert not errors, f"{path}: {doc.get('kind') or doc.get('aspectName')}: {errors[0].message}"
+            assert not errors, (
+                f"{path}: {doc.get('kind') or doc.get('aspectName')}: {errors[0].message}"
+            )
     assert checked > 0
 
 

--- a/tests/unit/test_loader_remote.py
+++ b/tests/unit/test_loader_remote.py
@@ -16,7 +16,6 @@ import requests
 
 from datahub_yaml_source.loader import discover_yaml_files, load_repository
 
-
 # --- S3 fakes -------------------------------------------------------------
 
 

--- a/tests/unit/test_markdown_docs_generation.py
+++ b/tests/unit/test_markdown_docs_generation.py
@@ -48,7 +48,15 @@ def test_generated_markdown_links_are_not_dangling():
     for line in markdown.splitlines():
         if line.startswith("## ") or line.startswith("### "):
             heading_text = line.lstrip("#").strip()
-            anchor = heading_text.lower().replace(" ", "-").replace("_", "-").replace(":", "").replace("(", "").replace(")", "").replace(".", "")
+            anchor = (
+                heading_text.lower()
+                .replace(" ", "-")
+                .replace("_", "-")
+                .replace(":", "")
+                .replace("(", "")
+                .replace(")", "")
+                .replace(".", "")
+            )
             headings.add(anchor)
 
     referenced_anchors = set(re.findall(r"\]\(#([a-z0-9\-]+)\)", markdown))

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -77,11 +77,25 @@ def test_dataset_doc_schema_block_parses_fields_and_foreign_keys():
                     {
                         "name": "fk_actes_patient",
                         "sourceFields": [
-                            {"platform": "postgres", "name": "actes", "env": "PROD", "fieldPath": "patient_id"}
+                            {
+                                "platform": "postgres",
+                                "name": "actes",
+                                "env": "PROD",
+                                "fieldPath": "patient_id",
+                            }
                         ],
-                        "foreignDataset": {"platform": "postgres", "name": "patient", "env": "PROD"},
+                        "foreignDataset": {
+                            "platform": "postgres",
+                            "name": "patient",
+                            "env": "PROD",
+                        },
                         "foreignFields": [
-                            {"platform": "postgres", "name": "patient", "env": "PROD", "fieldPath": "patient_id"}
+                            {
+                                "platform": "postgres",
+                                "name": "patient",
+                                "env": "PROD",
+                                "fieldPath": "patient_id",
+                            }
                         ],
                     }
                 ],
@@ -193,7 +207,12 @@ def test_data_process_instance_doc_coerces_single_run_event_dict_to_list():
             "id": "x",
             "name": "x",
             "created": {"timestampMillis": 1},
-            "parentTemplate": {"orchestrator": "airflow", "flowId": "f", "cluster": "PROD", "jobId": "j"},
+            "parentTemplate": {
+                "orchestrator": "airflow",
+                "flowId": "f",
+                "cluster": "PROD",
+                "jobId": "j",
+            },
             "runEvents": {"status": "STARTED", "timestampMillis": 1},
         }
     )

--- a/tests/unit/test_urns.py
+++ b/tests/unit/test_urns.py
@@ -1,7 +1,14 @@
 import pytest
 
 from datahub_yaml_source.loader import ParsedRepository
-from datahub_yaml_source.models import ContainerDoc, DatasetRef, DomainDoc, TagDoc
+from datahub_yaml_source.models import (
+    ContainerDoc,
+    DataFlowJobRef,
+    DataFlowRef,
+    DatasetRef,
+    DomainDoc,
+    TagDoc,
+)
 from datahub_yaml_source.urns import (
     ReferenceIndex,
     container_key,
@@ -15,14 +22,12 @@ from datahub_yaml_source.urns import (
     owner_urn,
     tag_urn,
 )
-from datahub_yaml_source.models import DataFlowJobRef, DataFlowRef
 
 
 def test_dataset_urn_without_platform_instance():
     ref = DatasetRef(platform="postgres", name="ehr.public.patient", env="PROD")
     assert (
-        dataset_urn(ref)
-        == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr.public.patient,PROD)"
+        dataset_urn(ref) == "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr.public.patient,PROD)"
     )
 
 
@@ -141,10 +146,22 @@ def test_container_urn_ignores_env_like_default_sdk_behavior():
     # entirely, so these two must collide (this is expected/desired: it's why
     # the known-good GUID above doesn't depend on env at all).
     prod = ContainerDoc.model_validate(
-        {"kind": "CONTAINER", "platform": "postgres", "database": "ehr", "env": "PROD", "name": "EHR"}
+        {
+            "kind": "CONTAINER",
+            "platform": "postgres",
+            "database": "ehr",
+            "env": "PROD",
+            "name": "EHR",
+        }
     )
     dev = ContainerDoc.model_validate(
-        {"kind": "CONTAINER", "platform": "postgres", "database": "ehr", "env": "DEV", "name": "EHR"}
+        {
+            "kind": "CONTAINER",
+            "platform": "postgres",
+            "database": "ehr",
+            "env": "DEV",
+            "name": "EHR",
+        }
     )
     assert container_urn(prod) == container_urn(dev)
 
@@ -176,14 +193,19 @@ def test_document_urn_is_stable_and_passes_through_full_urns():
 
 def test_owner_urn_builds_corpuser_unless_already_a_urn():
     assert owner_urn("datahub") == "urn:li:corpuser:datahub"
-    assert owner_urn("urn:li:corpGroup:eds-data-engineering") == "urn:li:corpGroup:eds-data-engineering"
+    assert (
+        owner_urn("urn:li:corpGroup:eds-data-engineering")
+        == "urn:li:corpGroup:eds-data-engineering"
+    )
 
 
 def test_data_flow_and_data_job_urns():
     flow_ref = DataFlowRef(orchestrator="airflow", flowId="ehr_to_raw", cluster="PROD")
     assert data_flow_urn(flow_ref) == "urn:li:dataFlow:(airflow,ehr_to_raw,PROD)"
 
-    job_ref = DataFlowJobRef(orchestrator="airflow", flowId="ehr_to_raw", cluster="PROD", jobId="patient_to_raw")
+    job_ref = DataFlowJobRef(
+        orchestrator="airflow", flowId="ehr_to_raw", cluster="PROD", jobId="patient_to_raw"
+    )
     job_urn = data_job_urn(job_ref)
     assert job_urn.startswith("urn:li:dataJob:")
     assert "patient_to_raw" in job_urn
@@ -212,10 +234,22 @@ def test_reference_index_flags_missing_tag_domain_and_container():
     assert index.has_domain("missing") is False
 
     known_container = ContainerDoc.model_validate(
-        {"kind": "CONTAINER", "platform": "postgres", "database": "ehr", "env": "PROD", "name": "EHR"}
+        {
+            "kind": "CONTAINER",
+            "platform": "postgres",
+            "database": "ehr",
+            "env": "PROD",
+            "name": "EHR",
+        }
     )
     unknown_container = ContainerDoc.model_validate(
-        {"kind": "CONTAINER", "platform": "postgres", "database": "other", "env": "PROD", "name": "Other"}
+        {
+            "kind": "CONTAINER",
+            "platform": "postgres",
+            "database": "other",
+            "env": "PROD",
+            "name": "Other",
+        }
     )
     assert index.has_container(known_container) is True
     assert index.has_container(unknown_container) is False
@@ -227,7 +261,13 @@ def test_reference_index_treats_containers_differing_only_by_instance_as_the_sam
     repo = ParsedRepository()
     repo.containers.append(
         ContainerDoc.model_validate(
-            {"kind": "CONTAINER", "platform": "postgres", "database": "ehr", "env": "PROD", "name": "EHR"}
+            {
+                "kind": "CONTAINER",
+                "platform": "postgres",
+                "database": "ehr",
+                "env": "PROD",
+                "name": "EHR",
+            }
         )
     )
     index = ReferenceIndex(repo)

--- a/tests/unit/test_yaml_source.py
+++ b/tests/unit/test_yaml_source.py
@@ -106,7 +106,9 @@ def test_get_workunits_internal_reports_warning_and_continues_when_builder_raise
 
     wus = list(source.get_workunits_internal())
 
-    tag_urns = {wu.metadata.entityUrn for wu in wus if wu.metadata.entityUrn == "urn:li:tag:still-processed"}
+    tag_urns = {
+        wu.metadata.entityUrn for wu in wus if wu.metadata.entityUrn == "urn:li:tag:still-processed"
+    }
     assert tag_urns  # the tag after the failing assertion was still emitted
     assert len(source.report.warnings) == 1
 


### PR DESCRIPTION
Résout **[Workflow qualite de code : Ruff + mypy](https://github.com/davidouagne/datahub-yaml-source/issues/2)** (`#2`), ticket `wayfinder:grilling` de la carte **[Mettre en place les workflows GitHub](https://github.com/davidouagne/datahub-yaml-source/issues/1)** (`#1`). La carte surcharge « Plan, don't do » : ce ticket décide *et* implémente.

## Décisions (grilling avec le mainteneur)

| # | Décision |
|---|----------|
| Config | `pyproject.toml` minimal (`[tool.ruff]` + `[tool.mypy]`), **sans** `[build-system]` — `setup.py` garde le packaging |
| Règles Ruff | `E, F, I, UP, B, C4, SIM, RUF`, `line-length = 100`, `target-version = "py310"` |
| `per-file-ignores` | `__init__.py` → `F401` ; `tests/**` → `E501` (URN/JSON littéraux insécables) |
| Reformat | Passe mécanique unique sur `src/`, `tests/`, `scripts/` pour qu'un check bloquant soit honnête dès le départ |
| mypy | `src/` uniquement, non-strict, `ignore_missing_imports` pour `datahub.*` / `deepdiff.*` ; **non bloquant** (`continue-on-error`) |
| Nom du job bloquant | `ruff` (chaîne stable pour la branch protection — ticket `#9`) |
| Outils | `ruff>=0.12,<0.13` + `mypy>=1.17` dans l'extra `dev` de `setup.py` |

## Contenu

**Commit 1 — `style:`** passe mécanique
- `pyproject.toml` (`[tool.ruff]`)
- `ruff format` (34 fichiers) + `ruff check --fix` (679 correctifs sûrs, dont les réécritures pyupgrade `Optional[X]` → `X | None` dans `models.py`)
- Correctifs manuels du résidu : alias `Union[...]` → `|`, 2 `SIM102`, 1 `UP038`, chaînes `Field(description=...)` longues passées en concaténation implicite (valeurs identiques au bit près), 2 `# noqa: E501` (matrice ASCII + docstring irréductible)
- `generate_markdown_docs.py` : `_render_type` traite désormais `types.UnionType` comme `typing.Union` → `reference.md` régénéré **identique au bit près**

**Commit 2 — `ci:`** l'outillage
- `.github/workflows/quality.yml` (job `ruff` bloquant, job `mypy (advisory)` non bloquant), conventions de `ci.yml`
- `[tool.mypy]` dans `pyproject.toml`, `ruff`/`mypy` dans l'extra `dev`
- `spec/spec-process-cicd-quality.md` (même format que `spec-process-cicd-ci.md`), avec la **base mypy actuelle : 31 erreurs / 11 fichiers** consignée, non masquée
- `spec/` retiré de `.gitignore` + `spec-process-cicd-ci.md` (préexistant) enfin versionné
- `CONTRIBUTING.md` : commandes locales `ruff check .` / `ruff format --check .` / `mypy`

## Vérification

- `ruff check .` → clean · `ruff format --check .` → `50 files already formatted`
- Régénération schéma + docs → **aucun diff**
- Suite complète : **210 tests unit + intégration passent**
- `mypy` : 31 erreurs (indicatif — non bloquant), consignées dans la spec

## Note pour le ticket `#9` (branch protection)

Le check requis pour le job Ruff est **`ruff`**. Par ailleurs `ci.yml` expose son job d'agrégat sous le nom `CI status` (le `name:` du job `ci-status`) — la chaîne de contexte réelle est `CI status`, pas `ci-status` comme l'indique actuellement le corps de `#9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)