### PR TITLE
fix: borner acryl-datahub <1.7.0.5 (CI de main cassée par le SDK expérimental)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,20 @@ setup(
         # >=1.6.0 for the SDK V2 constructor kwargs the cross-cutting aspect
         # helpers in builders/common.py depend on (e.g. DataFlow/DataJob's
         # `parent_container=`, `links=`, `structured_properties=`).
-        "acryl-datahub>=1.7.0",
+        #
+        # Upper bound <1.7.0.5: the (still ExperimentalWarning) datahub.sdk.*
+        # surface this connector builds on takes undeprecated breaks inside
+        # the 1.7.0.x series --
+        #   * 1.7.0.5: SemanticModel.add_dataset stops accepting bare
+        #     dataset URNs (now needs a SemanticModelDataset), breaking
+        #     builders/semantic.py and the integration golden;
+        #   * 1.7.0.8: the SupportStatus enum is renamed
+        #     (CERTIFIED/INCUBATING/TESTING -> ALPHA/BETA/GA), breaking
+        #     yaml_source.py's @support_status at import.
+        # 1.7.0.4 is the last release the suite passes on. Lifting this cap
+        # means migrating both call sites (and regenerating the golden) --
+        # tracked as its own task, not folded in here.
+        "acryl-datahub>=1.7.0,<1.7.0.5",
         "pyyaml>=6.0",
         # models.py/loader.py/yaml_source_config.py import pydantic directly
         # for the config schema and validation. Only ever a transitive dep


### PR DESCRIPTION
## Problème

La CI de `main` est rouge depuis une release d'`acryl-datahub` : le plancher était non borné (`>=1.7.0`) et la surface `datahub.sdk.*` sur laquelle ce connecteur s'appuie — livrée par DataHub avec un `ExperimentalWarning` explicite et **aucune garantie de compat** — a pris deux ruptures non dépréciées **dans la série de patch 1.7.0.x** :

| Release | Rupture | Impact |
|---|---|---|
| **1.7.0.5** | `SemanticModel.add_dataset` n'accepte plus une URN de dataset nue (exige un `SemanticModelDataset`) | `builders/semantic.py` lève ; `SEMANTIC_MODEL` / `METRIC` disparaissent du golden d'intégration |
| **1.7.0.8** | `SupportStatus` renommé `CERTIFIED/INCUBATING/TESTING` → `ALPHA/BETA/GA` | `yaml_source.py` `@support_status(SupportStatus.INCUBATING)` → `AttributeError` à l'import — c'est l'erreur de collecte actuellement rouge sur tous les PR |

Bisect (vérifié en installant chaque version) :

| Version | `add_dataset` URN nue | `SupportStatus.INCUBATING` | suite complète |
|---|---|---|---|
| 1.7.0.3 | ✅ | ✅ | 210 pass |
| **1.7.0.4** | ✅ | ✅ | **210 pass** |
| 1.7.0.5 – 1.7.0.7 | ❌ | ✅ | 3 fail |
| 1.7.0.8 – 1.7.0.9 | ❌ | ❌ | collecte interrompue |

## Ce PR

Une ligne : `acryl-datahub>=1.7.0` → `>=1.7.0,<1.7.0.5` (+ commentaire détaillant les deux ruptures et la version). `1.7.0.4` est la dernière release où `pytest tests/unit tests/integration` passe. Cohérent avec les autres deps de `setup.py`, toutes déjà bornées (`pydantic<3`, `requests<3`, `GitPython<4`, `boto3<2`).

**Aucun changement de code** : `SupportStatus.INCUBATING` et `semantic.py` restent tels quels.

## Suite (hors de ce PR)

Migrer vers `1.7.0.5+` / `1.7.0.8+` : réécrire `builders/semantic.py::add_dataset` pour des `SemanticModelDataset`, passer `@support_status` à `ALPHA`, régénérer le golden d'intégration. Vraie tâche de maintenance connecteur, à traiter séparément.

## Lien avec #10

[PR #10](https://github.com/davidouagne/datahub-yaml-source/pull/10) (workflow qualité de code) est rouge sur le job CI pour cette même raison — son job `ruff` est vert. Une fois ce PR mergé, #10 sera rebasé sur `main` et repassera au vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)