### PR TITLE
Versioning : dériver la version depuis les tags Git (setuptools-scm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v7
+        # Full history + tags so setuptools-scm derives the real version
+        # (pyproject.toml [tool.setuptools_scm]); a shallow clone would
+        # leave every install at the 0.0.0 fallback.
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v7
         with:
@@ -60,6 +65,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        # Full history + tags so setuptools-scm derives the real version
+        # (pyproject.toml [tool.setuptools_scm]); a shallow clone would
+        # leave every install at the 0.0.0 fallback.
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,6 +27,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        # Full history + tags so setuptools-scm derives the real version
+        # (pyproject.toml [tool.setuptools_scm]); a shallow clone would
+        # leave every install at the 0.0.0 fallback.
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v7
         with:
@@ -57,6 +62,11 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
+        # Full history + tags so setuptools-scm derives the real version
+        # (pyproject.toml [tool.setuptools_scm]); a shallow clone would
+        # leave every install at the 0.0.0 fallback.
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,27 @@
-# Tool configuration only. Packaging is still owned by setup.py (there is
-# deliberately no [build-system] table here); this file exists so Ruff and
-# mypy have the standard home they look for first. See
-# spec/spec-process-cicd-quality.md for the rationale behind each choice.
+# setup.py still holds the package metadata (deps, extras, entry points);
+# this file adds the PEP 517 build-system and the tool config that Ruff,
+# mypy and setuptools-scm look for here first. The package version is not
+# written anywhere -- setuptools-scm derives it from Git tags at build
+# time (see [tool.setuptools_scm] below and
+# spec/spec-process-cicd-quality.md / spec-process-cicd-ci.md for the CI
+# `fetch-depth: 0` this needs).
+
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8,<9"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# no-guess-dev: an untagged commit is X.Y.Z.post1.devN (explicitly "after
+#   the last release"), not X.Y.(Z+1).devN which would imply an unreleased
+#   future version that may never ship.
+# no-local-version: drop the +g<hash> local segment -- PyPI / TestPyPI
+#   reject local versions, so any non-tag build (e.g. a CI dev upload)
+#   stays valid. Clean tag builds are unaffected either way.
+# fallback_version: a build from a source archive with no .git and no
+#   SETUPTOOLS_SCM_PRETEND_VERSION degrades to 0.0.0 instead of hard-failing.
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
+fallback_version = "0.0.0"
 
 [tool.ruff]
 line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import find_packages, setup
 
 setup(
     name="datahub-yaml-source",
-    version="0.1.0",
+    # Version is derived from Git tags by setuptools-scm; see
+    # [tool.setuptools_scm] in pyproject.toml. Do not add a static
+    # version= here -- the presence of that table is what activates the
+    # plugin, and a static value would shadow it.
     description="DataHub ingestion source that reads declarative YAML metadata files.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/spec/spec-process-cicd-ci.md
+++ b/spec/spec-process-cicd-ci.md
@@ -1,8 +1,8 @@
 ---
 title: CI/CD Workflow Specification - CI
-version: 1.1
+version: 1.2
 date_created: 2026-08-16
-last_updated: 2026-08-16
+last_updated: 2026-09-05
 owner: David Ouagne
 tags: [process, cicd, github-actions, automation, python, datahub, pytest]
 ---
@@ -114,6 +114,11 @@ coverage_report: text           # Description: per-module coverage summary emitt
 - **Concurrency**: One in-flight run per ref; a new push cancels the previous run for the same ref (PERF-002).
 - **Resource Limits**: Standard hosted Linux runner; no elevated compute required (no compilation of native
   extensions beyond what `pip install` resolves from wheels).
+- **Checkout depth**: Every `actions/checkout` step uses `fetch-depth: 0` (full history + tags). The
+  package version is derived from Git tags by `setuptools-scm` (`pyproject.toml` `[tool.setuptools_scm]`);
+  under the default shallow clone `setuptools-scm` sees no tags and every install resolves to the
+  `0.0.0` fallback. This is a build-input requirement, not a behavioural one — the test suite itself
+  still contacts no network service.
 
 ### Environmental Constraints
 
@@ -245,6 +250,7 @@ loader's git/S3/HTTP code paths are exercised in the test suite exclusively thro
 |---------|------|---------|--------|
 | 1.0 | 2026-08-16 | Initial specification, written against a repository with no existing CI workflow | David Ouagne |
 | 1.1 | 2026-08-16 | Corrected the Python matrix from 3.9–3.12 to 3.10–3.12: `acryl-datahub>=1.7.0`, a mandatory dependency, itself requires Python >=3.10 (confirmed via its PyPI classifiers), so a 3.9 leg was unsatisfiable. Marked the workflow as implemented at `.github/workflows/ci.yml`. | David Ouagne |
+| 1.2 | 2026-09-05 | Added `fetch-depth: 0` to both `actions/checkout` steps: the package version is now derived from Git tags by `setuptools-scm` (issue #3), which needs full history + tags rather than the default shallow clone. | David Ouagne |
 
 ## Related Specifications
 

--- a/spec/spec-process-cicd-quality.md
+++ b/spec/spec-process-cicd-quality.md
@@ -1,6 +1,6 @@
 ---
 title: CI/CD Workflow Specification - Code Quality (Ruff + mypy)
-version: 1.0
+version: 1.1
 date_created: 2026-09-05
 last_updated: 2026-09-05
 owner: David Ouagne
@@ -95,6 +95,9 @@ mypy_result: status   # advisory; surfaced in logs, not consumed as a gate
   not Python-version-sensitive at the project's `target-version` (`py310`), so no matrix.
 - **Network**: Outbound to the Python package index only, for dependency installation.
 - **Permissions**: Read-only `contents` (SEC-001).
+- **Checkout depth**: Both `actions/checkout` steps use `fetch-depth: 0` (full history + tags), so
+  `setuptools-scm` (`pyproject.toml` `[tool.setuptools_scm]`) can derive the package version during
+  `pip install -e ".[dev]"`; a shallow clone would resolve every install to the `0.0.0` fallback.
 
 ## Tooling Configuration (authoritative pointers)
 
@@ -196,6 +199,7 @@ protection configuration for `main`.
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
 | 1.0 | 2026-09-05 | Initial specification. Ruff (blocking: `check` + `format --check`) and mypy (advisory, `continue-on-error`) added as `.github/workflows/quality.yml`; `[tool.ruff]` / `[tool.mypy]` introduced in a new `pyproject.toml`; `ruff`/`mypy` pinned in `setup.py`'s `dev` extra. One-off `ruff format` + safe `ruff check --fix` applied across `src/`, `tests/`, `scripts/`. Recorded mypy baseline: 31 errors / 11 files. | David Ouagne |
+| 1.1 | 2026-09-05 | Added `fetch-depth: 0` to both `actions/checkout` steps: `pyproject.toml` gained a `[build-system]` + `[tool.setuptools_scm]` (issue #3), so the editable install now needs full history + tags to resolve a real version. | David Ouagne |
 
 ## Related Specifications
 

--- a/src/datahub_yaml_source/__init__.py
+++ b/src/datahub_yaml_source/__init__.py
@@ -1,3 +1,11 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
 from datahub_yaml_source.yaml_source import YamlSource
 
 __all__ = ["YamlSource"]
+
+try:
+    __version__ = _version("datahub-yaml-source")
+except PackageNotFoundError:  # running from a source tree with no install
+    __version__ = "0.0.0"


### PR DESCRIPTION
Résout **[Versioning : adopter setuptools-scm](https://github.com/davidouagne/datahub-yaml-source/issues/3)** (`#3`), ticket `wayfinder:task` de la carte **[Mettre en place les workflows GitHub](https://github.com/davidouagne/datahub-yaml-source/issues/1)** (`#1`). La carte surcharge « Plan, don't do » : décide *et* implémente.

## Décisions (grilling avec le mainteneur)

| Question | Retenu |
|---|---|
| Source du `__version__` runtime | **`importlib.metadata`** (paquet toujours pip-installé) — pas de `_version.py` généré, rien à gitignorer |
| Exposer `__version__` | **Oui**, dans `src/datahub_yaml_source/__init__.py`, `try/except PackageNotFoundError` → `"0.0.0"` |
| `version_scheme` | **`no-guess-dev`** — commit hors-tag = `X.Y.Z.post1.devN`, n'implique pas de future version |
| `local_scheme` | **`no-local-version`** — pas de `+g<hash>`, tout build hors-tag reste uploadable sur PyPI/TestPyPI |
| `fallback_version` | **`0.0.0`** — build depuis archive sans `.git` dégrade au lieu de planter |
| Ajustement CI | **`fetch-depth: 0`** sur les 4 `actions/checkout` (`ci.yml` ×2, `quality.yml` ×2) |
| `[build-system]` | `setuptools>=64`, `setuptools-scm>=8,<9`, backend `setuptools.build_meta` |
| `setup.py` | **suppression pure** de `version="0.1.0"` (pas de `use_scm_version`, legacy en v8) |

## Contenu

- **`pyproject.toml`** : `[build-system]` + `[tool.setuptools_scm]` (schemes + fallback, rationale inline). En-tête réécrit (n'est plus « deliberately no [build-system] »).
- **`setup.py`** : ligne `version=` retirée.
- **`src/datahub_yaml_source/__init__.py`** : `__version__` via `importlib.metadata`.
- **`ci.yml` / `quality.yml`** : `fetch-depth: 0` sur chaque checkout, avec commentaire.
- **`spec-process-cicd-ci.md`** 1.1 → **1.2**, **`spec-process-cicd-quality.md`** 1.0 → **1.1** : contrainte « Checkout depth » + Version History.

## Vérification

- `SETUPTOOLS_SCM_PRETEND_VERSION=0.1.0 python -m build` → `datahub_yaml_source-0.1.0.{tar.gz,whl}` ✅ (étape de vérif du ticket)
- `python -m build` sur l'historique actuel (sans tag) → `0.0.post1.dev33` (segment local bien absent)
- `datahub check plugins` → `yaml` toujours enregistré
- Suite complète : **210 tests unit + intégration** + tests de drift schéma/docs : **pass**
- `ruff check .` / `ruff format --check .` : clean

## Conséquence à traiter dans #4

Mettre `setuptools-scm` dans `build-system.requires` active son *file-finder* : le sdist embarque désormais **tous les fichiers suivis par git** (`tests/`, `spec/`, `docs/`, `scripts/`, `.github/`, `AGENTS.md`…). Curation (`MANIFEST.in` avec `prune`, ou l'accepter) laissée au ticket **[Workflow release : PyPI (Trusted Publishing) + GitHub Release](https://github.com/davidouagne/datahub-yaml-source/issues/4)** (`#4`), qui configure le build de publication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)