### PR TITLE
README: PyPI, Python, licence badges (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # datahub-yaml-source
 
 [![CI](https://github.com/davidouagne/datahub-yaml-source/actions/workflows/ci.yml/badge.svg)](https://github.com/davidouagne/datahub-yaml-source/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/datahub-yaml-source)](https://pypi.org/project/datahub-yaml-source/)
+[![Python versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://pypi.org/project/datahub-yaml-source/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 A standalone [DataHub](https://datahubproject.io/) ingestion source plugin that
 reads a directory tree of declarative YAML "metadata as code" files and emits


### PR DESCRIPTION
## What

Adds three badges next to the existing CI badge at the top of `README.md`:

| Badge | Source | Note |
|---|---|---|
| PyPI version | shields `pypi/v/datahub-yaml-source` → PyPI project page | Reads **"not found"** until the first release (out of scope here) — expected, per #7 |
| Python versions | **static** `3.10 \| 3.11 \| 3.12` | Chose static over dynamic `pypi/pyversions`: the dynamic badge is also "not found" pre-release, while the static text is correct today and matches `setup.py`'s `python_requires` / classifiers and the CI matrix. Swap to dynamic after first release if preferred. |
| Licence | static `Apache 2.0` → `LICENSE` | |

## Verified

- `https://pypi.org/pypi/datahub-yaml-source/json` → 404 (package not yet published; name is correct, so the version badge's "not found" is the expected pre-release state).
- Both static shields endpoints → 200.
- No spec touched — README badges are not a CI/CD process (map Notes: spec-per-workflow).

Resolves #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)