### PR TITLE
Migrate to acryl-datahub 1.7.0.9+ (lift the <1.7.0.5 cap) (#12)

### DIFF
--- a/_PLANNING.md
+++ b/_PLANNING.md
@@ -89,8 +89,8 @@ Phase 5C. All 12 kinds targeted by Phase 5 have now shipped.
 | `MLFEATURE_TABLE` | `mlFeatureTable` | platform, name, mlFeatures, mlPrimaryKeys | Raw MCP (`MLFeatureTablePropertiesClass`) + `common_aspect_mcps()` |
 | `MLMODEL_GROUP` | `mlModelGroup` | platform, name, container | SDK V2 `MLModelGroup` + `common_sdk_kwargs()` (narrowed `native=`, no `subtype=`/`applications=`/`container=` kwarg) |
 | `MLMODEL` | `mlModel` | platform, name, modelGroup, mlFeatures, container, hyperParameters, type, full model card (intendedUse, ethicalConsiderations, caveatsAndRecommendations, trainingData, evaluationData, factorPrompts, metrics, sourceCode) | SDK V2 `MLModel` + `common_sdk_kwargs()` (same narrowed `native=`); model-card aspects always via `extra_aspects=` (valid only on `mlModel`, not a shared mixin) |
-| `SEMANTIC_MODEL` | `semanticModel` | platform, path, id, nativeDefinition, datasets, aiContext | SDK V2 `SemanticModel` + `common_sdk_kwargs()` (narrowed `native=`, no `subtype=`/`applications=` kwarg); `externalUrl` via `_ensure_model_props()` (no constructor kwarg, C9) |
-| `METRIC` | `metric` | platform, path, id, semanticModel (required), expression, derivedFrom, relatedMetrics, datasetUpstreams, aiContext | SDK V2 `Metric` + `common_sdk_kwargs()` (same narrowed `native=`); `externalUrl`/`relatedMetrics` via `_ensure_metric_props()`/`_ensure_metric_relationships()` (C9); emitted after `SEMANTIC_MODEL` — `semantic_model=` is a required constructor kwarg |
+| `SEMANTIC_MODEL` | `semanticModel` | platform, path, id, nativeDefinition, datasets, aiContext | SDK V2 `SemanticModel` + `common_sdk_kwargs()` (narrowed `native=`, no `subtype=`/`applications=` kwarg); `externalUrl` via `_ensure_model_props()` (no constructor kwarg, C9). `datasets` are **logical** `SemanticModelDataset` members (alias + inline schema + per-field `semanticFieldAnnotation` + lineage to physical sources), each emitted onto its own `dataset` URN on the model's platform — never a physical table (C11) |
+| `METRIC` | `metric` | platform, path, id, semanticModel (required), expression, derivedFrom, relatedMetrics, datasetUpstreams, aiContext | SDK V2 `Metric` + `common_sdk_kwargs()` (same narrowed `native=`); `externalUrl`/`relatedMetrics` via `_ensure_metric_props()`/`_ensure_metric_relationships()` (C9); `datasetUpstreams` via the `upstream_datasets=` constructor kwarg (SDK-owned since 1.7.0.5 — C11); emitted after `SEMANTIC_MODEL` — `semantic_model=` is a required constructor kwarg |
 | `REPOSITORY` | `repository` | id, name, defaultBranch, languages, license, homepageUrl, archived, source (externalUrl/externalId), forkOf, platform/instance | Raw MCP (`repositoryProperties`, `repositorySource`, `repositoryLineage`) + `common_aspect_mcps()`; `platform`/`instance` emit a standalone `dataPlatformInstance` aspect (no `Has*` mixin — see Phase 5C notes) |
 | `API` | `api` | id, name, externalUrl, sourceRepository, restApi (method/path), signature (schemaDefinition), platform/instance | Raw MCP (`apiProperties`, `restApiProperties`, `apiSignature`) + `common_aspect_mcps()` |
 | `AGENT_SKILL` | `agentSkill` | id, name, instructions, requiredTools (API ids — `array[Urn]` in the PDL, not free text), sourceRepository, platform/instance | Raw MCP (`agentSkillInfo`) + `common_aspect_mcps()`; no `subTypes` (registry doesn't permit it on `agentSkill`) |
@@ -166,7 +166,7 @@ emit workunits → support stateful stale-entity removal) is identical to an API
 
 ```
 datahub-yaml-source/
-├── setup.py                                  # own entry point + deps (pyyaml, acryl-datahub>=1.7.0)
+├── setup.py                                  # own entry point + deps (pyyaml, acryl-datahub>=1.7.0.9,<1.8)
 ├── src/
 │   └── datahub_yaml_source/
 │       ├── __init__.py                       # exports YamlSource
@@ -536,6 +536,41 @@ Two more traps, not spec-related:
   `HasLinks` mixin that contradicted the verified entity-registry matrix (`tag` doesn't
   support `institutionalMemory`) — caught by writing the matrix comment in `models.py`
   *before* the class declarations and checking each one against it.
+
+### C11 — the semantic-layer SDK took undeprecated breaks inside 1.7.0.x (issue #12)
+
+`datahub.sdk.*` ships with an explicit `ExperimentalWarning` and no ascending-compat
+guarantee. Between `1.7.0.4` (last green) and `1.7.0.9` it broke this connector in three
+places; `main` CI was capped at `<1.7.0.5` (issue #11) as a stopgap until #12 absorbed
+all three:
+
+1. **`SemanticModel` membership (1.7.0.5).** `SemanticModel(datasets=[<bare dataset URN>])`
+   is refused: *"requires a `SemanticModelDataset`; bare dataset URNs are not supported."*
+   `SemanticModelDataset` is not a pointer — it's a `Dataset` **subclass** whose
+   `as_workunits()` writes `schemaMetadata` / `subTypes` / `semanticModelProperties` /
+   per-field `semanticFieldAnnotation` onto the dataset URN it's keyed by. Pointing one at
+   a physical table would clobber that table's real schema.
+   **Decision (option B):** model `SEMANTIC_MODEL.datasets` as *logical* datasets —
+   `SemanticModelDatasetDoc` carries `alias` + an inline `schema` (`SemanticFieldSpecDoc`:
+   fieldPath / type / semanticType DIMENSION·MEASURE·FILTER·OTHER / …) + `sourceDatasets`
+   for physical lineage. Each lands on `urn:li:dataset:(<model platform>,<path>/<id>.<alias>,<env>)`
+   — its own URN, never a physical one. The `SemanticModel` no longer needs a `datasets`
+   URN list (`semanticModelInfo.datasets` is now `[]`); membership is the logical dataset's
+   `semanticModelProperties.semanticModel` back-reference. This is the aliased-dataset
+   sub-feature Phase 5B had deferred; `relationships` (aliased cross-dataset joins) is a
+   follow-up on top of it, still out of scope.
+2. **`Metric.metricUpstreams` became SDK-owned (1.7.0.5).** The SDK now constructs its own
+   (empty) `metricUpstreams`; our hand-built `MetricUpstreamsClass` in `extra_aspects`
+   raced with it and lost (the `metricRelationships` precedent, one aspect wider).
+   Fixed via the new `upstream_datasets=` constructor kwarg.
+3. **`SupportStatus` enum renamed (1.7.0.8).** `CERTIFIED`/`INCUBATING`/`TESTING` dropped
+   with no alias; `ALPHA`/`BETA`/`GA`/`UNKNOWN` replace them. `@support_status` now uses
+   `ALPHA` (grilling session #2, Q12: `ALPHA` = "early-stage, community/team-outside-Ingestion,
+   may change without notice" — the role `INCUBATING` played for non-core connectors;
+   `BETA` claims Ingestion-team maintenance, false here).
+
+Floor moved to `acryl-datahub>=1.7.0.9,<1.8` (upper bound kept — the surface can break again
+on a minor). mypy advisory baseline unchanged (31 / 11). CI tested green on 1.7.0.10.
 
 ## Known Limitations
 

--- a/docs/sources/yaml/reference.md
+++ b/docs/sources/yaml/reference.md
@@ -561,7 +561,7 @@ Plus these [common metadata fields](#common-metadata-fields), which every kind a
 
 ## SEMANTIC_MODEL
 
-A semantic-layer model (e.g. a dbt semantic model / Looker explore) -- the entity a METRIC is defined against. `relationships` (aliased cross-dataset joins) and `semanticContent` (vector embeddings) are deliberately out of scope: the former needs an aliased-dataset sub-feature this connector doesn't model, the latter is system-computed. See _PLANNING.md, Phase 5B.
+A semantic-layer model (e.g. a dbt semantic model / Looker explore) -- the entity a METRIC is defined against.  `datasets` are the model's *logical* datasets (aliased, schema-bearing views), authored inline via `SemanticModelDatasetDoc` -- the SDK stopped accepting bare dataset URNs for membership in acryl-datahub 1.7.0.5 (see _PLANNING.md, Phase 5B). `relationships` (aliased cross-dataset joins) and `semanticContent` (vector embeddings) remain out of scope: the latter is system-computed, the former is a follow-up on top of the aliased datasets now modelled here.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
@@ -574,7 +574,7 @@ A semantic-layer model (e.g. a dbt semantic model / Looker explore) -- the entit
 | `description` | string | no | - |  |
 | `externalUrl` | string | no | - |  |
 | `nativeDefinition` | string | no | - | The model's native source definition, e.g. its dbt YAML/SQL. |
-| `datasets` | list of [DatasetRef](#datasetref) | no | - | Datasets this semantic model is built from. |
+| `datasets` | list of SemanticModelDatasetDoc | no | - | Logical datasets this semantic model exposes (aliased, schema-bearing). |
 | `aiContext` | [AiContextDoc](#aicontextdoc) | no | - |  |
 
 Plus these [common metadata fields](#common-metadata-fields), which every kind accepts a subset of depending on what DataHub's entity registry permits:

--- a/docs/sources/yaml/schema/yaml-metadata.schema.json
+++ b/docs/sources/yaml/schema/yaml-metadata.schema.json
@@ -7946,9 +7946,176 @@
       "title": "SchemaFieldSpecDoc",
       "type": "object"
     },
+    "SemanticFieldSpecDoc": {
+      "description": "One field of a SEMANTIC_MODEL logical dataset (see `SemanticModelDatasetDoc`).\n\nMaps to the SDK's `SemanticFieldInput`; emits a `semanticFieldAnnotation` aspect on\nthe field. Unlike `SchemaFieldDoc` (a physical column) this carries semantic-layer\nintent: whether the field is a dimension, a measure, a filter, or plain metadata.",
+      "properties": {
+        "fieldPath": {
+          "title": "Fieldpath",
+          "type": "string"
+        },
+        "type": {
+          "default": "string",
+          "description": "Native type name, e.g. 'VARCHAR(255)', 'BIGINT'.",
+          "title": "Type",
+          "type": "string"
+        },
+        "semanticType": {
+          "default": "OTHER",
+          "description": "The field's role in the semantic model.",
+          "enum": [
+            "DIMENSION",
+            "MEASURE",
+            "FILTER",
+            "OTHER"
+          ],
+          "title": "Semantictype",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "nullable": {
+          "default": true,
+          "title": "Nullable",
+          "type": "boolean"
+        },
+        "partOfKey": {
+          "default": false,
+          "title": "Partofkey",
+          "type": "boolean"
+        },
+        "expression": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SQL expression for a derived field or measure.",
+          "title": "Expression"
+        },
+        "aggregationFunction": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "e.g. 'sum', 'count_distinct'. Only meaningful for a MEASURE.",
+          "title": "Aggregationfunction"
+        },
+        "isTimeDimension": {
+          "default": false,
+          "title": "Istimedimension",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "fieldPath"
+      ],
+      "title": "SemanticFieldSpecDoc",
+      "type": "object"
+    },
+    "SemanticModelDatasetDoc": {
+      "additionalProperties": true,
+      "description": "A *logical* dataset a SEMANTIC_MODEL exposes: an aliased, schema-bearing view,\ndistinct from any physical source table.\n\nEmits onto its own dataset URN -- platform = the model's platform, name defaults to\n``<model path>/<model id>.<alias>`` -- so it never collides with a physical DATASET\ndocument. `sourceDatasets` records the physical lineage. See _PLANNING.md, Phase 5B.",
+      "properties": {
+        "alias": {
+          "description": "Alias used to reference this dataset in metric expressions.",
+          "title": "Alias",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Logical dataset name; defaults to '<model path>/<model id>.<alias>'.",
+          "title": "Name"
+        },
+        "env": {
+          "default": "PROD",
+          "title": "Env",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "viewDefinition": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The view's native SQL/definition.",
+          "title": "Viewdefinition"
+        },
+        "schema": {
+          "items": {
+            "$ref": "#/$defs/SemanticFieldSpecDoc"
+          },
+          "title": "Schema",
+          "type": "array"
+        },
+        "sourceDatasets": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/DatasetRef"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Physical dataset(s) this logical dataset is derived from.",
+          "title": "Sourcedatasets"
+        }
+      },
+      "required": [
+        "alias"
+      ],
+      "title": "SemanticModelDatasetDoc",
+      "type": "object"
+    },
     "SemanticModelDoc": {
       "additionalProperties": true,
-      "description": "A semantic-layer model (e.g. a dbt semantic model / Looker explore) -- the entity a\nMETRIC is defined against. `relationships` (aliased cross-dataset joins) and\n`semanticContent` (vector embeddings) are deliberately out of scope: the former needs\nan aliased-dataset sub-feature this connector doesn't model, the latter is\nsystem-computed. See _PLANNING.md, Phase 5B.",
+      "description": "A semantic-layer model (e.g. a dbt semantic model / Looker explore) -- the entity a\nMETRIC is defined against.\n\n`datasets` are the model's *logical* datasets (aliased, schema-bearing views), authored\ninline via `SemanticModelDatasetDoc` -- the SDK stopped accepting bare dataset URNs for\nmembership in acryl-datahub 1.7.0.5 (see _PLANNING.md, Phase 5B). `relationships`\n(aliased cross-dataset joins) and `semanticContent` (vector embeddings) remain out of\nscope: the latter is system-computed, the former is a follow-up on top of the aliased\ndatasets now modelled here.",
       "properties": {
         "subTypes": {
           "anyOf": [
@@ -8170,7 +8337,7 @@
           "anyOf": [
             {
               "items": {
-                "$ref": "#/$defs/DatasetRef"
+                "$ref": "#/$defs/SemanticModelDatasetDoc"
               },
               "type": "array"
             },
@@ -8179,7 +8346,7 @@
             }
           ],
           "default": null,
-          "description": "Datasets this semantic model is built from.",
+          "description": "Logical datasets this semantic model exposes (aliased, schema-bearing).",
           "title": "Datasets"
         },
         "aiContext": {

--- a/setup.py
+++ b/setup.py
@@ -49,19 +49,18 @@ setup(
         # helpers in builders/common.py depend on (e.g. DataFlow/DataJob's
         # `parent_container=`, `links=`, `structured_properties=`).
         #
-        # Upper bound <1.7.0.5: the (still ExperimentalWarning) datahub.sdk.*
-        # surface this connector builds on takes undeprecated breaks inside
-        # the 1.7.0.x series --
-        #   * 1.7.0.5: SemanticModel.add_dataset stops accepting bare
-        #     dataset URNs (now needs a SemanticModelDataset), breaking
-        #     builders/semantic.py and the integration golden;
-        #   * 1.7.0.8: the SupportStatus enum is renamed
-        #     (CERTIFIED/INCUBATING/TESTING -> ALPHA/BETA/GA), breaking
-        #     yaml_source.py's @support_status at import.
-        # 1.7.0.4 is the last release the suite passes on. Lifting this cap
-        # means migrating both call sites (and regenerating the golden) --
-        # tracked as its own task, not folded in here.
-        "acryl-datahub>=1.7.0,<1.7.0.5",
+        # Floor >=1.7.0.9: the (still ExperimentalWarning) datahub.sdk.*
+        # surface this connector builds on took two undeprecated breaks
+        # inside the 1.7.0.x series, both absorbed in issue #12 --
+        #   * 1.7.0.5: SemanticModel membership no longer accepts bare
+        #     dataset URNs; builders/semantic.py now builds
+        #     SemanticModelDataset (alias + resolved schema);
+        #   * 1.7.0.8: the SupportStatus enum was renamed
+        #     (CERTIFIED/INCUBATING/TESTING -> ALPHA/BETA/GA);
+        #     yaml_source.py's @support_status now uses ALPHA.
+        # Upper bound <1.8: the datahub.sdk.* surface is still
+        # ExperimentalWarning-flagged, so a minor bump can break again.
+        "acryl-datahub>=1.7.0.9,<1.8",
         "pyyaml>=6.0",
         # models.py/loader.py/yaml_source_config.py import pydantic directly
         # for the config schema and validation. Only ever a transitive dep

--- a/spec/spec-process-cicd-ci.md
+++ b/spec/spec-process-cicd-ci.md
@@ -1,6 +1,6 @@
 ---
 title: CI/CD Workflow Specification - CI
-version: 1.4
+version: 1.5
 date_created: 2026-08-16
 last_updated: 2026-09-07
 owner: David Ouagne
@@ -233,7 +233,7 @@ protection. Applied via `PUT /repos/davidouagne/datahub-yaml-source/branches/mai
 | PR modifies `models.py` and regenerates docs/schema correctly | `test` job passes | Standard test run |
 | Optional extra (`git`, `s3`) dependency accidentally imported at module level in core code | `minimal-install-check` fails at import time | Confirmed empirically: a base-only install (no extras) imports the plugin entry point successfully today |
 | Contributor runs `--update-golden-files` locally and commits an unintended change | Not caught by this workflow directly — CI compares against whatever golden file is committed | Relies on human review of the golden-file diff, as instructed in `CONTRIBUTING.md` |
-| Dependency floor (`acryl-datahub>=1.7.0`) resolves a newer release that drops a transitive dependency the code relies on (`requests`, `pydantic`) | Install or import may fail unpredictably | Not currently guarded by a pinned upper bound; a floating risk noted for future hardening, not fixed by this workflow alone |
+| A new `acryl-datahub` release within the pinned range (`>=1.7.0.9,<1.8`) breaks the experimental `datahub.sdk.*` surface this connector builds on | `test` job fails on the affected leg | The `<1.8` upper bound (issue #12) contains the blast radius to a minor; Dependabot opens the bump as its own PR (`spec/spec-process-cicd-dependabot.md`), reviewed by hand. A break inside the patch range still needs a fix + a tighter pin, as in #11/#12. |
 
 ## Validation Criteria
 
@@ -272,6 +272,7 @@ protection. Applied via `PUT /repos/davidouagne/datahub-yaml-source/branches/mai
 | 1.2 | 2026-09-05 | Added `fetch-depth: 0` to both `actions/checkout` steps: the package version is now derived from Git tags by `setuptools-scm` (issue #3), which needs full history + tags rather than the default shallow clone. | David Ouagne |
 | 1.3 | 2026-09-07 | Dependent Workflows table: added Dependabot (`.github/dependabot.yml`, issue #6) as an upstream PR producer this workflow gates; refreshed the stale "Release/publish (not yet specified)" row to point at the now-existing `spec/spec-process-cicd-release.md`. No workflow-file change. | David Ouagne |
 | 1.4 | 2026-09-07 | Documented `main` branch protection (issue #9): new "Branch protection on `main`" subsection with the concrete config (required checks `CI status` + `ruff` only; `strict: false`; no required reviews; `enforce_admins: false`). Corrected the recurring `ci-status` → `CI status` conflation — branch protection matches the job's `name:` (`CI status`, with a space), not the job id `ci-status`. No workflow-file change. | David Ouagne |
+| 1.5 | 2026-09-07 | Refreshed the `acryl-datahub` dependency-range Edge Case row: the floor is now `>=1.7.0.9,<1.8` (issue #12 lifted the `<1.7.0.5` stopgap and kept a `<1.8` bound). No workflow-file change. | David Ouagne |
 
 ## Related Specifications
 

--- a/src/datahub_yaml_source/builders/semantic.py
+++ b/src/datahub_yaml_source/builders/semantic.py
@@ -3,12 +3,17 @@
 from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.metadata.schema_classes import EdgeClass, MetricUpstreamsClass
+from datahub.metadata.schema_classes import EdgeClass
 from datahub.sdk.metric import AiContextInput, Metric
-from datahub.sdk.semantic_model import SemanticModel
+from datahub.sdk.semantic_model import SemanticFieldInput, SemanticModel, SemanticModelDataset
 
 from datahub_yaml_source.builders.common import common_sdk_kwargs
-from datahub_yaml_source.models import AiContextDoc, MetricDoc, SemanticModelDoc
+from datahub_yaml_source.models import (
+    AiContextDoc,
+    MetricDoc,
+    SemanticModelDatasetDoc,
+    SemanticModelDoc,
+)
 from datahub_yaml_source.urns import ReferenceIndex, dataset_urn, metric_urn, semantic_model_urn
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
@@ -33,11 +38,52 @@ def _ai_context_input(doc: AiContextDoc | None) -> AiContextInput | None:
     )
 
 
+def _semantic_model_dataset(
+    member: SemanticModelDatasetDoc, doc: SemanticModelDoc, sm_urn: str
+) -> SemanticModelDataset:
+    """Build one logical dataset of a SEMANTIC_MODEL.
+
+    Lands on its own URN (the model's platform, name defaulting to
+    ``<path>/<id>.<alias>``) so it never collides with a physical DATASET document.
+    """
+    name = member.name or f"{doc.path}/{doc.id}.{member.alias}"
+    return SemanticModelDataset(
+        platform=doc.platform,
+        name=name,
+        env=member.env,
+        platform_instance=doc.instance,
+        semantic_model=sm_urn,
+        alias=member.alias,
+        description=member.description,
+        view_definition=member.viewDefinition,
+        schema=[
+            SemanticFieldInput(
+                field_path=f.fieldPath,
+                type=f.type,
+                semantic_type=f.semanticType,
+                description=f.description,
+                nullable=f.nullable,
+                is_part_of_key=f.partOfKey,
+                expression=f.expression,
+                aggregation_function=f.aggregationFunction,
+                is_time_dimension=f.isTimeDimension,
+            )
+            for f in member.fields
+        ],
+        upstreams=(
+            [dataset_urn(d) for d in member.sourceDatasets] if member.sourceDatasets else None
+        ),
+    )
+
+
 def build_semantic_model(
     doc: SemanticModelDoc, index: ReferenceIndex, report: YamlSourceReport
 ) -> Iterable[MetadataWorkUnit]:
     context = f"SEMANTIC_MODEL '{doc.id}'"
     common = common_sdk_kwargs(doc, index, report, context, native=_SEMANTIC_ENTITY_NATIVE_KWARGS)
+
+    sm_urn = semantic_model_urn(doc)
+    members = [_semantic_model_dataset(m, doc, sm_urn) for m in (doc.datasets or [])]
 
     model = SemanticModel(
         platform=doc.platform,
@@ -47,7 +93,7 @@ def build_semantic_model(
         name=doc.displayName,
         description=doc.description,
         native_definition=doc.nativeDefinition,
-        datasets=[dataset_urn(d) for d in doc.datasets] if doc.datasets else None,
+        datasets=members or None,
         ai_context=_ai_context_input(doc.aiContext),
         **common,
     )
@@ -55,6 +101,12 @@ def build_semantic_model(
         model._ensure_model_props().externalUrl = doc.externalUrl
 
     yield from model.as_workunits()
+    # Each logical dataset is a distinct `dataset` entity (aliased view + its own schema +
+    # per-field semanticFieldAnnotation + lineage to the physical sources); it carries the
+    # membership back-reference (`semanticModelProperties.semanticModel`), so `SemanticModel`
+    # itself no longer needs a `datasets` URN list.
+    for member in members:
+        yield from member.as_workunits()
 
 
 def build_metric(
@@ -62,19 +114,6 @@ def build_metric(
 ) -> Iterable[MetadataWorkUnit]:
     context = f"METRIC '{doc.id}'"
     common = common_sdk_kwargs(doc, index, report, context, native=_SEMANTIC_ENTITY_NATIVE_KWARGS)
-
-    # `metricUpstreams` has no SDK involvement at all (unlike `metricRelationships`,
-    # which the SDK partially owns -- see below), so it's a plain extra_aspects entry.
-    extra_aspects = list(common.get("extra_aspects") or [])
-    if doc.datasetUpstreams:
-        extra_aspects.append(
-            MetricUpstreamsClass(
-                datasetUpstreams=[
-                    EdgeClass(destinationUrn=dataset_urn(d)) for d in doc.datasetUpstreams
-                ]
-            )
-        )
-    common["extra_aspects"] = extra_aspects or None
 
     metric = Metric(
         platform=doc.platform,
@@ -86,6 +125,12 @@ def build_metric(
         description=doc.description,
         expression=doc.expression,
         derived_from=[metric_urn(m) for m in doc.derivedFrom] if doc.derivedFrom else None,
+        # `metricUpstreams` became SDK-owned in acryl-datahub 1.7.0.5 (like
+        # `metricRelationships` below); a second `extra_aspects` entry would race with the
+        # SDK's own empty one and lose. Use the constructor kwarg.
+        upstream_datasets=(
+            [dataset_urn(d) for d in doc.datasetUpstreams] if doc.datasetUpstreams else None
+        ),
         ai_context=_ai_context_input(doc.aiContext),
         **common,
     )

--- a/src/datahub_yaml_source/models.py
+++ b/src/datahub_yaml_source/models.py
@@ -1059,6 +1059,58 @@ class SemanticModelRef(BaseModel):
     id: str
 
 
+class SemanticFieldSpecDoc(BaseModel):
+    """One field of a SEMANTIC_MODEL logical dataset (see `SemanticModelDatasetDoc`).
+
+    Maps to the SDK's `SemanticFieldInput`; emits a `semanticFieldAnnotation` aspect on
+    the field. Unlike `SchemaFieldDoc` (a physical column) this carries semantic-layer
+    intent: whether the field is a dimension, a measure, a filter, or plain metadata.
+    """
+
+    fieldPath: str
+    type: str = Field(
+        default="string", description="Native type name, e.g. 'VARCHAR(255)', 'BIGINT'."
+    )
+    semanticType: Literal["DIMENSION", "MEASURE", "FILTER", "OTHER"] = Field(
+        default="OTHER", description="The field's role in the semantic model."
+    )
+    description: str | None = None
+    nullable: bool = True
+    partOfKey: bool = False
+    expression: str | None = Field(
+        default=None, description="SQL expression for a derived field or measure."
+    )
+    aggregationFunction: str | None = Field(
+        default=None, description="e.g. 'sum', 'count_distinct'. Only meaningful for a MEASURE."
+    )
+    isTimeDimension: bool = False
+
+
+class SemanticModelDatasetDoc(_AllowExtraFields):
+    """A *logical* dataset a SEMANTIC_MODEL exposes: an aliased, schema-bearing view,
+    distinct from any physical source table.
+
+    Emits onto its own dataset URN -- platform = the model's platform, name defaults to
+    ``<model path>/<model id>.<alias>`` -- so it never collides with a physical DATASET
+    document. `sourceDatasets` records the physical lineage. See _PLANNING.md, Phase 5B.
+    """
+
+    alias: str = Field(description="Alias used to reference this dataset in metric expressions.")
+    name: str | None = Field(
+        default=None,
+        description="Logical dataset name; defaults to '<model path>/<model id>.<alias>'.",
+    )
+    env: str = "PROD"
+    description: str | None = None
+    viewDefinition: str | None = Field(
+        default=None, description="The view's native SQL/definition."
+    )
+    fields: list[SemanticFieldSpecDoc] = Field(default_factory=list, alias="schema")
+    sourceDatasets: list[DatasetRef] | None = Field(
+        default=None, description="Physical dataset(s) this logical dataset is derived from."
+    )
+
+
 class MetricRef(BaseModel):
     """Reference to a METRIC by its natural (platform, path, id) key."""
 
@@ -1080,10 +1132,14 @@ class SemanticModelDoc(
     _AllowExtraFields,
 ):
     """A semantic-layer model (e.g. a dbt semantic model / Looker explore) -- the entity a
-    METRIC is defined against. `relationships` (aliased cross-dataset joins) and
-    `semanticContent` (vector embeddings) are deliberately out of scope: the former needs
-    an aliased-dataset sub-feature this connector doesn't model, the latter is
-    system-computed. See _PLANNING.md, Phase 5B."""
+    METRIC is defined against.
+
+    `datasets` are the model's *logical* datasets (aliased, schema-bearing views), authored
+    inline via `SemanticModelDatasetDoc` -- the SDK stopped accepting bare dataset URNs for
+    membership in acryl-datahub 1.7.0.5 (see _PLANNING.md, Phase 5B). `relationships`
+    (aliased cross-dataset joins) and `semanticContent` (vector embeddings) remain out of
+    scope: the latter is system-computed, the former is a follow-up on top of the aliased
+    datasets now modelled here."""
 
     kind: Literal["SEMANTIC_MODEL"]
     platform: str = Field(description="e.g. 'dbt', 'looker'.")
@@ -1096,8 +1152,9 @@ class SemanticModelDoc(
     nativeDefinition: str | None = Field(
         default=None, description="The model's native source definition, e.g. its dbt YAML/SQL."
     )
-    datasets: list[DatasetRef] | None = Field(
-        default=None, description="Datasets this semantic model is built from."
+    datasets: list[SemanticModelDatasetDoc] | None = Field(
+        default=None,
+        description="Logical datasets this semantic model exposes (aliased, schema-bearing).",
     )
     aiContext: AiContextDoc | None = None
 

--- a/src/datahub_yaml_source/yaml_source.py
+++ b/src/datahub_yaml_source/yaml_source.py
@@ -93,7 +93,7 @@ def _resolve_aws_connection(aws_connection_config: dict[str, Any] | None) -> Any
 
 @platform_name("YAML Metadata")
 @config_class(YamlSourceConfig)
-@support_status(SupportStatus.INCUBATING)
+@support_status(SupportStatus.ALPHA)
 @capability(SourceCapability.SCHEMA_METADATA, "Enabled by default via DATASET documents")
 @capability(SourceCapability.CONTAINERS, "Enabled by default via CONTAINER documents")
 @capability(SourceCapability.LINEAGE_COARSE, "Fully declared in YAML, no SQL parsing involved")

--- a/tests/integration/yaml_source/resources/ml-layer/models.yml
+++ b/tests/integration/yaml_source/resources/ml-layer/models.yml
@@ -111,9 +111,27 @@ description: Active patient cohort semantic model
 nativeDefinition: |-
   select * from {{ ref('ehr_public_patient') }} where actif
 datasets:
-  - platform: postgres
-    name: ehr_public_patient
-    env: PROD
+  - alias: patients
+    description: Active-patient view exposed by the semantic model
+    schema:
+      - fieldPath: patient_id
+        type: BIGSERIAL
+        semanticType: OTHER
+        partOfKey: true
+      - fieldPath: nom
+        type: VARCHAR(255)
+        semanticType: DIMENSION
+      - fieldPath: date_naissance
+        type: DATE
+        semanticType: DIMENSION
+        isTimeDimension: true
+      - fieldPath: actif
+        type: BOOLEAN
+        semanticType: FILTER
+    sourceDatasets:
+      - platform: postgres
+        name: ehr_public_patient
+        env: PROD
 aiContext:
   synonyms:
     - active cohort

--- a/tests/integration/yaml_source/yaml_source_mces_golden.json
+++ b/tests/integration/yaml_source/yaml_source_mces_golden.json
@@ -3190,13 +3190,11 @@
             "name": "Patients actifs",
             "description": "Active patient cohort semantic model",
             "nativeDefinition": "select * from {{ ref('ehr_public_patient') }} where actif",
-            "datasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
-            ]
+            "datasets": []
         }
     },
     "systemMetadata": {
-        "lastObserved": 1787120785899,
+        "lastObserved": 1788774417289,
         "runId": "yaml-source-golden-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -3239,21 +3237,277 @@
     }
 },
 {
-    "entityType": "metric",
-    "entityUrn": "urn:li:metric:(urn:li:dataPlatform:dbt,models/marts,taux_readmission_30j)",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "metricUpstreams",
+    "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "datasetUpstreams": [
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417290,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
                 {
-                    "destinationUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)",
+                    "type": "TRANSFORMED"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1787120785899,
+        "lastObserved": 1788774417290,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "Active-patient view exposed by the semantic model",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417290,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Semantic Model Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417290,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "semanticModelProperties",
+    "aspect": {
+        "json": {
+            "alias": "patients",
+            "semanticModel": "urn:li:semanticModel:(urn:li:dataPlatform:dbt,models/marts,patients_actifs)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417291,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "",
+            "platform": "urn:li:dataPlatform:dbt",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "patient_id",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "BIGSERIAL",
+                    "recursive": false,
+                    "isPartOfKey": true
+                },
+                {
+                    "fieldPath": "nom",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR(255)",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "date_naissance",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.DateType": {}
+                        }
+                    },
+                    "nativeDataType": "DATE",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "actif",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BooleanType": {}
+                        }
+                    },
+                    "nativeDataType": "BOOLEAN",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417292,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD),patient_id)",
+    "changeType": "UPSERT",
+    "aspectName": "semanticFieldAnnotation",
+    "aspect": {
+        "json": {
+            "type": "OTHER",
+            "expression": {
+                "dialects": [
+                    {
+                        "dialect": "ANSI_SQL",
+                        "expression": "patients.patient_id"
+                    }
+                ]
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417292,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD),nom)",
+    "changeType": "UPSERT",
+    "aspectName": "semanticFieldAnnotation",
+    "aspect": {
+        "json": {
+            "type": "DIMENSION",
+            "expression": {
+                "dialects": [
+                    {
+                        "dialect": "ANSI_SQL",
+                        "expression": "patients.nom"
+                    }
+                ]
+            },
+            "dimension": {
+                "isTime": false
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417293,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD),date_naissance)",
+    "changeType": "UPSERT",
+    "aspectName": "semanticFieldAnnotation",
+    "aspect": {
+        "json": {
+            "type": "DIMENSION",
+            "expression": {
+                "dialects": [
+                    {
+                        "dialect": "ANSI_SQL",
+                        "expression": "patients.date_naissance"
+                    }
+                ]
+            },
+            "dimension": {
+                "isTime": true
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417293,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD),actif)",
+    "changeType": "UPSERT",
+    "aspectName": "semanticFieldAnnotation",
+    "aspect": {
+        "json": {
+            "type": "FILTER",
+            "expression": {
+                "dialects": [
+                    {
+                        "dialect": "ANSI_SQL",
+                        "expression": "patients.actif"
+                    }
+                ]
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417294,
         "runId": "yaml-source-golden-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -3344,6 +3598,26 @@
     },
     "systemMetadata": {
         "lastObserved": 1787120785901,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "metric",
+    "entityUrn": "urn:li:metric:(urn:li:dataPlatform:dbt,models/marts,taux_readmission_30j)",
+    "changeType": "UPSERT",
+    "aspectName": "metricUpstreams",
+    "aspect": {
+        "json": {
+            "datasetUpstreams": [
+                {
+                    "destinationUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787120785899,
         "runId": "yaml-source-golden-test",
         "lastRunId": "no-run-id-provided"
     }
@@ -5153,6 +5427,22 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417325,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:duckdb,warehouse_raw_layer_patient,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
@@ -5387,6 +5677,70 @@
     },
     "systemMetadata": {
         "lastObserved": 1787120785926,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD),actif)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417329,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD),date_naissance)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417329,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD),nom)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417329,
+        "runId": "yaml-source-golden-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD),patient_id)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788774417330,
         "runId": "yaml-source-golden-test",
         "lastRunId": "no-run-id-provided"
     }

--- a/tests/unit/test_builders_semantic.py
+++ b/tests/unit/test_builders_semantic.py
@@ -27,7 +27,18 @@ def test_build_semantic_model_emits_info_and_ai_context():
             "displayName": "Patients actifs",
             "description": "Active patient cohort",
             "nativeDefinition": "select * from ehr_public_patient where actif",
-            "datasets": [{"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}],
+            "datasets": [
+                {
+                    "alias": "patients",
+                    "schema": [
+                        {"fieldPath": "patient_id", "type": "BIGSERIAL", "partOfKey": True},
+                        {"fieldPath": "nom", "type": "VARCHAR(255)", "semanticType": "DIMENSION"},
+                    ],
+                    "sourceDatasets": [
+                        {"platform": "postgres", "name": "ehr_public_patient", "env": "PROD"}
+                    ],
+                }
+            ],
             "aiContext": {"synonyms": ["active cohort"], "instructions": "Use for headcount"},
             "externalUrl": "https://dbt.example.org/marts/patients_actifs",
             "tags": ["pii"],
@@ -48,9 +59,6 @@ def test_build_semantic_model_emits_info_and_ai_context():
     )
     assert info.name == "Patients actifs"
     assert info.externalUrl == "https://dbt.example.org/marts/patients_actifs"
-    assert info.datasets == [
-        "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
-    ]
 
     ai_context = next(
         wu.metadata.aspect
@@ -60,6 +68,41 @@ def test_build_semantic_model_emits_info_and_ai_context():
     assert ai_context.synonyms == ["active cohort"]
 
     assert any(wu.metadata.aspect.__class__.__name__ == "GlobalTagsClass" for wu in wus)
+
+    # The logical dataset lands on its own `dbt`-platform URN (never the physical table),
+    # carries the membership back-reference, and re-exposes its schema + lineage.
+    member_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:dbt,models/marts/patients_actifs.patients,PROD)"
+    )
+    member_wus = [wu for wu in wus if wu.metadata.entityUrn == member_urn]
+    assert member_wus, "expected a logical-dataset entity for the semantic model member"
+
+    props = next(
+        wu.metadata.aspect
+        for wu in member_wus
+        if wu.metadata.aspect.__class__.__name__ == "SemanticModelPropertiesClass"
+    )
+    assert props.alias == "patients"
+    assert (
+        props.semanticModel
+        == "urn:li:semanticModel:(urn:li:dataPlatform:dbt,models/marts,patients_actifs)"
+    )
+
+    schema = next(
+        wu.metadata.aspect
+        for wu in member_wus
+        if wu.metadata.aspect.__class__.__name__ == "SchemaMetadataClass"
+    )
+    assert [f.fieldPath for f in schema.fields] == ["patient_id", "nom"]
+
+    upstream = next(
+        wu.metadata.aspect
+        for wu in member_wus
+        if wu.metadata.aspect.__class__.__name__ == "UpstreamLineageClass"
+    )
+    assert [u.dataset for u in upstream.upstreams] == [
+        "urn:li:dataset:(urn:li:dataPlatform:postgres,ehr_public_patient,PROD)"
+    ]
 
 
 def test_build_metric_requires_semantic_model_and_emits_upstreams_and_relationships():


### PR DESCRIPTION
Absorbs the three undeprecated breaks the experimental `datahub.sdk.*` surface took inside the `1.7.0.x` patch series. The `<1.7.0.5` stopgap from #11 is lifted; upper bound kept at `<1.8`. Suite green on `1.7.0.10`.

## The three breaks

**1. `SemanticModel` membership (1.7.0.5) — option B.** The SDK stopped accepting bare dataset URNs. `SemanticModelDataset` turned out to be a `Dataset` **subclass** whose `as_workunits()` writes `schemaMetadata` / `subTypes` / `semanticModelProperties` / per-field `semanticFieldAnnotation` onto the URN it's keyed by — pointing one at a physical table would clobber that table's real schema.

`SEMANTIC_MODEL.datasets` is now a list of **logical** datasets:
- `SemanticModelDatasetDoc`: `alias` (required) + inline `schema` (`SemanticFieldSpecDoc`: `fieldPath` / `type` / `semanticType` DIMENSION·MEASURE·FILTER·OTHER / `description` / `nullable` / `partOfKey` / `expression` / `aggregationFunction` / `isTimeDimension`) + `sourceDatasets` for physical lineage.
- Each lands on its own URN — `urn:li:dataset:(<model platform>,<path>/<id>.<alias>,<env>)` — never a physical one.
- `SemanticModel` no longer carries a `datasets` URL list (`semanticModelInfo.datasets` is now `[]`); membership is the logical dataset's `semanticModelProperties.semanticModel` back-reference.
- This is the aliased-dataset sub-feature Phase 5B had deferred; `relationships` (aliased cross-dataset joins) is a follow-up on top of it, still out of scope.

**2. `Metric.metricUpstreams` became SDK-owned (1.7.0.5).** Our hand-built `MetricUpstreamsClass` in `extra_aspects` raced with the SDK's own empty one and lost (the `metricRelationships` precedent, one aspect wider). Now via the `upstream_datasets=` constructor kwarg.

**3. `SupportStatus` enum renamed (1.7.0.8).** `INCUBATING` → `ALPHA` (dropped with no alias; `ALPHA` = "early-stage, community/team-outside-Ingestion, may change without notice" — the role `INCUBATING` played for non-core connectors, per grilling #2 Q12).

## Golden diff — reviewed by hand

- **Changed (1):** `semanticModelInfo.datasets` `[postgres,ehr_public_patient]` → `[]`.
- **Added (15):** all on the new logical dataset `urn:li:dataset:(dbt,models/marts/patients_actifs.patients,PROD)` and its schema fields — `schemaMetadata`, `datasetProperties`, `subTypes` (`"Semantic Model Dataset"`), `semanticModelProperties` (alias `patients` + back-ref), `upstreamLineage` → `postgres,ehr_public_patient` (`TRANSFORMED`), and per-field `semanticFieldAnnotation` + `status` for `patient_id` (OTHER) / `nom` (DIMENSION) / `date_naissance` (DIMENSION, isTime) / `actif` (FILTER).
- **Removed (0).** The physical `ehr_public_patient` DATASET is untouched — no collision.

`systemMetadata` for the 254 unchanged aspects is carried over verbatim so the JSON diff shows only the real change.

## Also

- JSON schema + `reference.md` regenerated (`models.py` changed).
- Fixture `ml-layer/models.yml` SEMANTIC_MODEL entry updated to the new shape (4 fields, a FILTER on `actif`, `sourceDatasets` → the physical table).
- Unit tests updated: `test_builders_semantic.py` asserts the logical-dataset entity (props / schema / lineage); the METRIC test's `upstream_datasets` assertion passes again.
- mypy advisory baseline **unchanged** (31 / 11) — verified, no spec update needed there.
- `_PLANNING.md`: new `C11` subsection + entity-table rows for SEMANTIC_MODEL / METRIC + `setup.py` dep line.
- `spec/spec-process-cicd-ci.md` → 1.5: `acryl-datahub` dependency-range Edge Case row refreshed to `>=1.7.0.9,<1.8`.

Resolves #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
