### PR TITLE
Drive the mypy baseline to zero + make it blocking (#13)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -52,14 +52,12 @@ jobs:
         run: ruff format --check --diff .
 
   mypy:
-    # Advisory only: mypy currently reports a known, non-empty error
-    # baseline (see the spec). continue-on-error keeps a regression
-    # visible in the run without blocking merge. Promoting this to a
-    # required check is tracked as fog on the wayfinder map (issue #1).
-    name: mypy (advisory)
+    # Blocking (issue #13). The mypy baseline was driven to zero, so a new
+    # type error now fails the build. This job's name is a required status
+    # check wired into branch protection for `main` -- keep it stable ("mypy").
+    name: mypy
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
         # Full history + tags so setuptools-scm derives the real version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,14 +85,15 @@ checks CI runs (`.github/workflows/quality.yml`, contract in
 ```bash
 ruff check .            # lint (blocking in CI)
 ruff format --check .   # formatting (blocking in CI); drop --check to apply
-mypy                    # type check over src/ (advisory in CI, not a gate)
+mypy                    # type check over src/ (blocking in CI)
 ```
 
 `ruff check --fix .` auto-fixes most lint findings. `ruff` config
 (`[tool.ruff]`, line length 100, target `py310`) and `mypy` config
-(`[tool.mypy]`, `src/` only, non-strict) both live in `pyproject.toml`. mypy
-currently has a known non-empty error baseline — see the spec — so a new mypy
-error won't fail CI, but don't add to it.
+(`[tool.mypy]`, `src/` only, non-strict) both live in `pyproject.toml`. The mypy
+baseline is zero — `mypy` must exit clean before a PR can merge. Fix a new error
+with a real annotation/guard; a `# type: ignore[<code>]` is a last resort and
+needs a one-line reason.
 
 ## Submitting changes
 

--- a/docs/sources/yaml/reference.md
+++ b/docs/sources/yaml/reference.md
@@ -84,7 +84,7 @@ A glossary category/folder that groups related glossary terms.
 | `name` | string | **yes** | - |  |
 | `definition` | string | no | - |  |
 | `parentNode` | string | no | - | id of a parent GLOSSARY_NODE, for nested categories. |
-| `displayProperties` | DisplayPropertiesDoc | no | - |  |
+| `displayProperties` | [DisplayPropertiesDoc](#displaypropertiesdoc) | no | - |  |
 
 Plus these [common metadata fields](#common-metadata-fields), which every kind accepts a subset of depending on what DataHub's entity registry permits:
 
@@ -112,7 +112,7 @@ A glossary term. Referenced elsewhere via `glossaryTerms: [<id>]`.
 | `termSource` | string | no | - | e.g. 'EXTERNAL' or 'INTERNAL'. |
 | `sourceRef` | string | no | - | Name of the external source this term came from, if termSource is EXTERNAL. |
 | `sourceUrl` | string | no | - |  |
-| `displayProperties` | DisplayPropertiesDoc | no | - |  |
+| `displayProperties` | [DisplayPropertiesDoc](#displaypropertiesdoc) | no | - |  |
 
 Plus these [common metadata fields](#common-metadata-fields), which every kind accepts a subset of depending on what DataHub's entity registry permits:
 
@@ -155,7 +155,7 @@ A business domain, used to group related datasets/data products. Referenced else
 | `name` | string | **yes** | - |  |
 | `description` | string | no | - |  |
 | `parentDomain` | string | no | - | id of a parent DOMAIN, for nested domain trees. |
-| `displayProperties` | DisplayPropertiesDoc | no | - |  |
+| `displayProperties` | [DisplayPropertiesDoc](#displaypropertiesdoc) | no | - |  |
 
 Plus these [common metadata fields](#common-metadata-fields), which every kind accepts a subset of depending on what DataHub's entity registry permits:
 
@@ -1211,6 +1211,8 @@ Only `schemaDefinition` (free text) is exposed -- structured input/output field 
 | `models` | list of [MLModelRef](#mlmodelref) | no | - | MLMODEL entities this agent relies on. |
 
 ### DisplayPropertiesDoc
+
+Colour surfaced in the DataHub UI. Emits the `displayProperties` aspect. (`icon` is not supported yet -- DataHub's `IconPropertiesClass` needs an icon library/name/style triple with no natural single-field shorthand.)
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |

--- a/docs/sources/yaml/schema/yaml-metadata.schema.json
+++ b/docs/sources/yaml/schema/yaml-metadata.schema.json
@@ -324,7 +324,7 @@
         "displayProperties": {
           "anyOf": [
             {
-              "$ref": "#/$defs/datahub_yaml_source__models__DisplayPropertiesDoc__2"
+              "$ref": "#/$defs/DisplayPropertiesDoc"
             },
             {
               "type": "null"
@@ -3948,6 +3948,25 @@
       "title": "DeprecationDoc",
       "type": "object"
     },
+    "DisplayPropertiesDoc": {
+      "description": "Colour surfaced in the DataHub UI. Emits the `displayProperties` aspect.\n(`icon` is not supported yet -- DataHub's `IconPropertiesClass` needs an\nicon library/name/style triple with no natural single-field shorthand.)",
+      "properties": {
+        "colorHex": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Colorhex"
+        }
+      },
+      "title": "DisplayPropertiesDoc",
+      "type": "object"
+    },
     "DocumentDoc": {
       "additionalProperties": true,
       "description": "A knowledge-base document (a runbook, a FAQ, an AI-context note, ...).\n`document` permits owners/tags/glossaryTerms/domains/links/\nstructuredProperties/subTypes, but not applications or deprecation.",
@@ -4309,7 +4328,7 @@
         "displayProperties": {
           "anyOf": [
             {
-              "$ref": "#/$defs/datahub_yaml_source__models__DisplayPropertiesDoc__1"
+              "$ref": "#/$defs/DisplayPropertiesDoc"
             },
             {
               "type": "null"
@@ -4632,7 +4651,7 @@
         "displayProperties": {
           "anyOf": [
             {
-              "$ref": "#/$defs/datahub_yaml_source__models__DisplayPropertiesDoc__1"
+              "$ref": "#/$defs/DisplayPropertiesDoc"
             },
             {
               "type": "null"
@@ -4935,7 +4954,7 @@
         "displayProperties": {
           "anyOf": [
             {
-              "$ref": "#/$defs/datahub_yaml_source__models__DisplayPropertiesDoc__1"
+              "$ref": "#/$defs/DisplayPropertiesDoc"
             },
             {
               "type": "null"
@@ -9005,43 +9024,6 @@
         "viewLogic"
       ],
       "title": "ViewPropertiesDoc",
-      "type": "object"
-    },
-    "datahub_yaml_source__models__DisplayPropertiesDoc__1": {
-      "description": "Colour surfaced in the DataHub UI. Emits the `displayProperties` aspect.\n(`icon` is not supported yet -- DataHub's `IconPropertiesClass` needs an\nicon library/name/style triple with no natural single-field shorthand.)",
-      "properties": {
-        "colorHex": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Colorhex"
-        }
-      },
-      "title": "DisplayPropertiesDoc",
-      "type": "object"
-    },
-    "datahub_yaml_source__models__DisplayPropertiesDoc__2": {
-      "properties": {
-        "colorHex": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Colorhex"
-        }
-      },
-      "title": "DisplayPropertiesDoc",
       "type": "object"
     }
   }

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
             # must agree on the exact ruleset.
             "ruff>=0.12,<0.13",
             "mypy>=1.17",
+            "types-PyYAML>=6.0",
         ],
     },
     entry_points={

--- a/spec/spec-process-cicd-ci.md
+++ b/spec/spec-process-cicd-ci.md
@@ -1,6 +1,6 @@
 ---
 title: CI/CD Workflow Specification - CI
-version: 1.5
+version: 1.6
 date_created: 2026-08-16
 last_updated: 2026-09-07
 owner: David Ouagne
@@ -193,16 +193,16 @@ maintainer with no second reviewer available:
 
 | Setting | Value | Rationale |
 |---------|-------|-----------|
-| Required status checks | exactly **`CI status`** (this workflow's aggregate gate) and **`ruff`** (`spec/spec-process-cicd-quality.md`) | The two blocking gates. Names are the check-run `name:` values, matched verbatim. |
+| Required status checks | exactly **`CI status`** (this workflow's aggregate gate), **`ruff`** and **`mypy`** (`spec/spec-process-cicd-quality.md`) | The three blocking gates. Names are the check-run `name:` values, matched verbatim. |
 | `strict` (require branch up to date before merge) | `false` | Would force every open PR — including the batch of Dependabot PRs — to be updated after each merge; not worth the friction for one maintainer. |
 | CodeQL / `Analyze (*)` | **not required** | Advisory only at this stage (map issue #1 Notes; `spec/spec-process-cicd-codeql.md`). |
-| `mypy (advisory)` | **not required** | `continue-on-error` job by design (`spec/spec-process-cicd-quality.md` REQ-006). |
 | `required_pull_request_reviews` | none | No second reviewer exists; a review requirement would be self-blocking. |
 | `enforce_admins` | `false` | The maintainer keeps a direct-push escape hatch to avoid locking themselves out. |
 | `restrictions` | none | Single maintainer; no push allow-list needed. |
 
-Renaming the `CI status` or `ruff` check is a breaking change: update this list and re-apply the
-protection. Applied via `PUT /repos/davidouagne/datahub-yaml-source/branches/main/protection`.
+Renaming the `CI status`, `ruff` or `mypy` check is a breaking change: update this list and re-apply
+the protection. Applied via `PUT /repos/davidouagne/datahub-yaml-source/branches/main/protection`.
+`mypy` was added to the set when it was promoted to blocking (issue #13).
 
 ## Compliance & Governance
 
@@ -273,6 +273,7 @@ protection. Applied via `PUT /repos/davidouagne/datahub-yaml-source/branches/mai
 | 1.3 | 2026-09-07 | Dependent Workflows table: added Dependabot (`.github/dependabot.yml`, issue #6) as an upstream PR producer this workflow gates; refreshed the stale "Release/publish (not yet specified)" row to point at the now-existing `spec/spec-process-cicd-release.md`. No workflow-file change. | David Ouagne |
 | 1.4 | 2026-09-07 | Documented `main` branch protection (issue #9): new "Branch protection on `main`" subsection with the concrete config (required checks `CI status` + `ruff` only; `strict: false`; no required reviews; `enforce_admins: false`). Corrected the recurring `ci-status` → `CI status` conflation — branch protection matches the job's `name:` (`CI status`, with a space), not the job id `ci-status`. No workflow-file change. | David Ouagne |
 | 1.5 | 2026-09-07 | Refreshed the `acryl-datahub` dependency-range Edge Case row: the floor is now `>=1.7.0.9,<1.8` (issue #12 lifted the `<1.7.0.5` stopgap and kept a `<1.8` bound). No workflow-file change. | David Ouagne |
+| 1.6 | 2026-09-07 | Added `mypy` to `main`'s required status checks (issue #13 promoted it to blocking). No workflow-file change in *this* spec's scope (`ci.yml` untouched). | David Ouagne |
 
 ## Related Specifications
 

--- a/spec/spec-process-cicd-quality.md
+++ b/spec/spec-process-cicd-quality.md
@@ -1,8 +1,8 @@
 ---
 title: CI/CD Workflow Specification - Code Quality (Ruff + mypy)
-version: 1.1
+version: 1.2
 date_created: 2026-09-05
-last_updated: 2026-09-05
+last_updated: 2026-09-07
 owner: David Ouagne
 tags: [process, cicd, github-actions, automation, python, lint, format, typing, ruff, mypy]
 ---
@@ -10,9 +10,10 @@ tags: [process, cicd, github-actions, automation, python, lint, format, typing, 
 ## Workflow Overview
 
 **Purpose**: On every push and pull request, enforce a single lint + format standard for all
-first-party Python (`src/`, `tests/`, `scripts/`) via Ruff, and surface (without gating) static
-type-checking findings from mypy over the package source. Complements `spec/spec-process-cicd-ci.md`,
-which owns install/test/coverage; this workflow owns style and typing only.
+first-party Python (`src/`, `tests/`, `scripts/`) via Ruff, and enforce a clean static
+type-check of the package source with mypy. Complements `spec/spec-process-cicd-ci.md`,
+which owns install/test/coverage; this workflow owns style and typing only. Both jobs are
+blocking (issue #13 drove the mypy baseline to zero).
 
 **Trigger Events**: Push to `main`; pull request targeting `main`; manual dispatch.
 
@@ -26,19 +27,19 @@ which owns install/test/coverage; this workflow owns style and typing only.
 ```mermaid
 graph TD
     A[Trigger: push / PR to main / manual] --> B[ruff: check + format --check]
-    A --> C["mypy (advisory, continue-on-error)"]
+    A --> C[mypy: type-check src/]
 
     style A fill:#e1f5fe
     style B fill:#e8f5e8
-    style C fill:#fff3e0
+    style C fill:#e8f5e8
 ```
 
 ## Jobs & Dependencies
 
 | Job Name | Purpose | Blocking? | Dependencies | Execution Context |
 |----------|---------|-----------|--------------|-------------------|
-| `ruff` | `ruff check` (lint) + `ruff format --check` (format) over the repo. Its job name is the stable required-check string for branch protection on `main`. | Yes | None | Linux runner, Python 3.12 |
-| `mypy (advisory)` | Run mypy over `src/` using the `[tool.mypy]` config in `pyproject.toml`. Reports findings in the run log; never fails the workflow (`continue-on-error: true`). | No | None | Linux runner, Python 3.12 |
+| `ruff` | `ruff check` (lint) + `ruff format --check` (format) over the repo. Its job name is a stable required-check string for branch protection on `main`. | Yes | None | Linux runner, Python 3.12 |
+| `mypy` | Run mypy over `src/` using the `[tool.mypy]` config in `pyproject.toml`. Fails the workflow on any error. Its job name is a stable required-check string for branch protection on `main`. | Yes | None | Linux runner, Python 3.12 |
 
 ## Requirements Matrix
 
@@ -50,9 +51,9 @@ graph TD
 | REQ-002 | Enforce a single auto-format. | High | `ruff format --check .` reports no file would be reformatted. |
 | REQ-003 | Lint/format config is version-controlled and single-source. | High | `[tool.ruff]` lives in `pyproject.toml`; no competing `ruff.toml`/`setup.cfg` lint config exists. |
 | REQ-004 | Tool versions match between CI and a local `pip install -e ".[dev]"`. | Medium | `ruff` and `mypy` are pinned in `setup.py`'s `dev` extra; the workflow installs only that extra, no ad-hoc tool install. |
-| REQ-005 | Run mypy over the package source and surface its output. | Medium | `mypy` runs against `files = ["src"]`; findings appear in the job log. |
-| REQ-006 | mypy never blocks merge (for now). | High | The `mypy` job is `continue-on-error: true`; a non-zero mypy exit does not fail the workflow or any required check. |
-| REQ-007 | The blocking check has one stable name for branch protection. | High | The blocking job is named exactly `ruff`; renaming it is a breaking change requiring a branch-protection update (see `spec/spec-process-cicd-ci.md` REQ-007 for the analogous `ci-status`). |
+| REQ-005 | Type-check the package source with mypy. | High | `mypy` runs against `files = ["src"]` with the `[tool.mypy]` config; a clean tree exits 0. |
+| REQ-006 | A new type error blocks merge. | High | The `mypy` job has no `continue-on-error`; a non-zero mypy exit fails the workflow and the required check. The baseline is zero (issue #13). |
+| REQ-007 | Each blocking check has one stable name for branch protection. | High | The blocking jobs are named exactly `ruff` and `mypy`; renaming either is a breaking change requiring a branch-protection update (see `spec/spec-process-cicd-ci.md` "Branch protection on `main`"). |
 
 ### Security Requirements
 
@@ -134,15 +135,22 @@ schema + docs (per `AGENTS.md`) and confirming no drift.
 | `check_untyped_defs` | `true` | Type-check bodies of unannotated functions — most of the value on a codebase with sparse annotations. |
 | `warn_unused_ignores`, `warn_redundant_casts` | `true` | Low-noise staleness detectors. |
 | overrides: `datahub.*`, `deepdiff.*` | `ignore_missing_imports = true` | `acryl-datahub` ships partial/absent type information; without this the log is dominated by import errors rather than findings about our code. |
-| `strict` | *not set* | Advisory job; a strict baseline would be noise, not signal. Tightening toward strict is tracked as fog on the wayfinder map. |
+| `strict` | *not set* | A strict baseline would be noise on a codebase with sparse annotations. Tightening toward strict, once the SDK's own types improve, is a possible future step. |
 
-### Known mypy baseline
+### mypy baseline: zero (issue #13)
 
-At v1.0 of this spec, `mypy` reports **31 errors across 11 files** (chiefly `arg-type` mismatches
-where our models pass `list[str]` / `str | None` into `acryl-datahub` SDK constructors that expect
-`list[str | SomeUrn]` / `str`). This is recorded, not suppressed: the job is advisory precisely so
-this baseline is visible and can be driven down before mypy is promoted to blocking. There is no
-mypy baseline/ignore file and no `# type: ignore` sweep.
+At v1.0–1.1 of this spec `mypy` reported **31 errors across 11 files** (all pre-existing; it was the
+first time mypy had run on the repo). Issue #13 drove that to **zero** and flipped the job to
+blocking. The 31 broke down as: `list[str]` passed where the SDK types `list[str | SomeUrn]` (fixed
+by widening our helper return annotations); `str | None` reaching a `list[str]` / `str` param (fixed
+with explicit guards / `assert`s documenting a validator invariant); `*Doc` passed where a `*Ref`
+was typed (fixed with structural `Protocol`s in `urns.py`); `AssertionInfoClass(**payload)` (an
+intermediate `dict[str, Any]`); a stale 5-tuple `NaturalKey` alias (aligned to the real 3-tuple); a
+duplicate `DisplayPropertiesDoc` class (deleted); `types-PyYAML` added to the `dev` extra; and one
+genuine bug — a CUSTOM assertion passed a `SchemaFieldSpec` where `field=` wants a schemaField URN
+string. No `mypy` baseline/ignore file, and **no `# type: ignore` comments** — every error was
+resolved by a real annotation, guard, `cast`, or fix. `warn_unused_ignores` stays on so any future
+suppression can't silently rot.
 
 ## Error Handling Strategy
 
@@ -150,7 +158,7 @@ mypy baseline/ignore file and no `# type: ignore` sweep.
 |------------|----------|------------------|
 | Lint violation | Fail the `ruff` job | Run `ruff check --fix .` locally; hand-fix what `--fix` won't. |
 | Formatting difference | Fail the `ruff` job | Run `ruff format .` locally and commit. |
-| mypy error(s) | Logged; job still succeeds (`continue-on-error`) | Address opportunistically; drives the baseline in this spec down over time. |
+| mypy error(s) | Fail the `mypy` job | Fix the annotation/guard, or (last resort, with a justifying comment) `# type: ignore[<code>]`. |
 | Dependency install failure | Fail the affected job | Investigate resolution against `setup.py`. |
 
 ## Quality Gates
@@ -159,7 +167,7 @@ mypy baseline/ignore file and no `# type: ignore` sweep.
 |------|----------|---------------------|
 | Lint | `ruff check .` clean | None; rule-set changes require updating this spec. |
 | Format | `ruff format --check .` clean | None. |
-| Types | mypy run completes and output is captured | Never a gate at this spec version; promotion requires a spec update. |
+| Types | `mypy` exits 0 over `src/` | None; the baseline is zero. New errors must be fixed, not suppressed without cause. |
 
 ## Integration Points
 
@@ -167,15 +175,15 @@ mypy baseline/ignore file and no `# type: ignore` sweep.
 
 | Workflow | Relationship | Trigger Mechanism |
 |----------|---------------|---------------------|
-| Branch protection on `main` | Consumes the `ruff` check as a required status check | GitHub branch protection API (see the branch-protection ticket on wayfinder map issue #1) |
+| Branch protection on `main` | Consumes both `ruff` and `mypy` as required status checks | GitHub branch protection API (see `spec/spec-process-cicd-ci.md` "Branch protection on `main`") |
 | `spec/spec-process-cicd-ci.md` (CI) | Sibling; disjoint responsibility (install/test/coverage). Both gate `main`. | Same trigger events |
 
 ## Validation Criteria
 
 - **VLD-001**: On a branch with a deliberate lint violation, the `ruff` job fails.
 - **VLD-002**: On a branch with an unformatted file, the `ruff` job fails with a diff in the log.
-- **VLD-003**: On a branch that adds a new mypy error, the workflow still concludes successfully and
-  the `mypy (advisory)` job shows the error in its log.
+- **VLD-003**: On a branch that adds a new mypy error, the `mypy` job fails and the workflow
+  concludes unsuccessfully.
 - **VLD-004**: No job in this workflow references a secret.
 - **VLD-005**: `pip install -e ".[dev]"` on a clean checkout provides `ruff` and `mypy` at the
   versions the workflow runs.
@@ -191,8 +199,8 @@ mypy baseline/ignore file and no `# type: ignore` sweep.
 4. **Testing**: Confirm the Validation Criteria on a trial PR.
 5. **Deployment**: Merge once the trial run conforms.
 
-Renaming the `ruff` job, or promoting `mypy` to blocking, additionally requires updating the branch
-protection configuration for `main`.
+Renaming the `ruff` or `mypy` job additionally requires updating the branch protection configuration
+for `main` (its required status checks match job names verbatim).
 
 ### Version History
 
@@ -200,6 +208,7 @@ protection configuration for `main`.
 |---------|------|---------|--------|
 | 1.0 | 2026-09-05 | Initial specification. Ruff (blocking: `check` + `format --check`) and mypy (advisory, `continue-on-error`) added as `.github/workflows/quality.yml`; `[tool.ruff]` / `[tool.mypy]` introduced in a new `pyproject.toml`; `ruff`/`mypy` pinned in `setup.py`'s `dev` extra. One-off `ruff format` + safe `ruff check --fix` applied across `src/`, `tests/`, `scripts/`. Recorded mypy baseline: 31 errors / 11 files. | David Ouagne |
 | 1.1 | 2026-09-05 | Added `fetch-depth: 0` to both `actions/checkout` steps: `pyproject.toml` gained a `[build-system]` + `[tool.setuptools_scm]` (issue #3), so the editable install now needs full history + tags to resolve a real version. | David Ouagne |
+| 1.2 | 2026-09-07 | **mypy promoted to blocking** (issue #13). Baseline driven 31 → 0 with real fixes (no `# type: ignore`, no baseline file); one genuine bug fixed on the way (CUSTOM assertion `field=`). Job renamed `mypy (advisory)` → `mypy`, `continue-on-error` removed. `types-PyYAML` added to the `dev` extra. `mypy` added to `main`'s required status checks alongside `ruff`. | David Ouagne |
 
 ## Related Specifications
 

--- a/src/datahub_yaml_source/builders/application.py
+++ b/src/datahub_yaml_source/builders/application.py
@@ -25,7 +25,11 @@ def _application_lineage_edges(
                 f"{context} applicationLineage.{direction}[{i}] must set "
                 f"exactly one of 'api' or 'dataset'"
             )
-        destination_urn = api_urn(edge.api) if edge.api else dataset_urn(edge.dataset)
+        if edge.api:
+            destination_urn = api_urn(edge.api)
+        else:
+            assert edge.dataset is not None  # guaranteed by the exactly-one check above
+            destination_urn = dataset_urn(edge.dataset)
         result.append(EdgeClass(destinationUrn=destination_urn))
     return result
 

--- a/src/datahub_yaml_source/builders/assertion.py
+++ b/src/datahub_yaml_source/builders/assertion.py
@@ -1,6 +1,8 @@
 import re
 from collections.abc import Iterable
+from typing import Any
 
+from datahub.emitter.mce_builder import make_schema_field_urn
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     AssertionActionClass,
@@ -170,15 +172,11 @@ def _build_data_schema_assertion(doc: AssertionDoc) -> SchemaAssertionInfoClass:
 
 def _build_custom_assertion(doc: AssertionDoc) -> CustomAssertionInfoClass:
     a = doc.assertion
-    field_spec = (
-        SchemaFieldSpecClass(
-            path=a.fieldPath, type=a.dataType or "string", nativeType=a.nativeDataType or ""
-        )
-        if a.fieldPath
-        else None
-    )
+    # `CustomAssertionInfoClass.field` is a schemaField URN string, not a
+    # SchemaFieldSpec -- build the URN from the dataset URN + the column path.
+    field_urn = make_schema_field_urn(a.entityUrn, a.fieldPath) if a.fieldPath else None
     return CustomAssertionInfoClass(
-        type=a.customType or "CUSTOM", entity=a.entityUrn, field=field_spec, logic=a.logic or ""
+        type=a.customType or "CUSTOM", entity=a.entityUrn, field=field_urn, logic=a.logic or ""
     )
 
 
@@ -228,12 +226,15 @@ def build_assertion(
             }
         )
 
+    # The sub-assertion kwarg name is chosen from `_BUILDERS` at runtime; `Any`
+    # is the honest element type for that dispatch.
+    sub_assertion_kwarg: dict[str, Any] = {kwarg_name: sub_assertion}
     aspect = AssertionInfoClass(
         type=doc.assertion.type,
         description=doc.description,
         customProperties=custom_properties,
         source=AssertionSourceClass(type=doc.sourceType),
-        **{kwarg_name: sub_assertion},
+        **sub_assertion_kwarg,
     )
     yield mcp_workunit(entity_urn, aspect)
 

--- a/src/datahub_yaml_source/builders/common.py
+++ b/src/datahub_yaml_source/builders/common.py
@@ -69,7 +69,20 @@ from datahub_yaml_source.urns import (
 DEFAULT_ACTOR_URN = "urn:li:corpuser:datahub"
 ZERO_AUDIT_STAMP = AuditStampClass(time=0, actor=DEFAULT_ACTOR_URN)
 
-_TYPE_MAP = {
+# Every value is one of the classes `SchemaFieldDataTypeClass(type=...)` accepts;
+# the explicit union keeps that guarantee visible to the type checker.
+_SchemaNativeType = (
+    type[NumberTypeClass]
+    | type[StringTypeClass]
+    | type[BooleanTypeClass]
+    | type[DateTypeClass]
+    | type[TimeTypeClass]
+    | type[BytesTypeClass]
+    | type[RecordTypeClass]
+    | type[NullTypeClass]
+)
+
+_TYPE_MAP: dict[str, _SchemaNativeType] = {
     "number": NumberTypeClass,
     "string": StringTypeClass,
     "boolean": BooleanTypeClass,

--- a/src/datahub_yaml_source/builders/container.py
+++ b/src/datahub_yaml_source/builders/container.py
@@ -21,7 +21,9 @@ from datahub_yaml_source.urns import (
 )
 from datahub_yaml_source.yaml_source_report import YamlSourceReport
 
-NaturalKey = tuple[str, object, str, object, str]
+# Mirrors `urns.container_natural_key()`: (platform, database, schema-or-None).
+# `instance`/`env` are deliberately excluded -- they never affect a container's URN.
+NaturalKey = tuple[str, str, str | None]
 
 
 def topological_sort_containers(containers: list[ContainerDoc]) -> list[ContainerDoc]:

--- a/src/datahub_yaml_source/builders/data_flow_job.py
+++ b/src/datahub_yaml_source/builders/data_flow_job.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import ContainerClass
+from datahub.metadata.urns import DatasetUrn
 from datahub.sdk.dataflow import DataFlow
 from datahub.sdk.datajob import DataJob
 
@@ -55,8 +56,9 @@ def build_data_job(
     context = f"DATA_JOB '{doc.jobId}'"
     common = common_sdk_kwargs(doc, index, report, context)
 
-    input_urns = [dataset_urn(ref) for ref in (doc.inputDatasets or [])]
-    output_urns = [dataset_urn(ref) for ref in (doc.outputDatasets or [])]
+    # `str | DatasetUrn` element type matches DataJob's inlets/outlets params.
+    input_urns: list[str | DatasetUrn] = [dataset_urn(ref) for ref in (doc.inputDatasets or [])]
+    output_urns: list[str | DatasetUrn] = [dataset_urn(ref) for ref in (doc.outputDatasets or [])]
     input_job_urns = [data_job_urn(ref) for ref in (doc.inputDataJobs or [])]
     fine_grained = build_fine_grained_lineage_list(doc.fineGrainedLineages)
 

--- a/src/datahub_yaml_source/builders/dataset.py
+++ b/src/datahub_yaml_source/builders/dataset.py
@@ -99,7 +99,6 @@ def build_dataset(
     context = f"DATASET '{doc.name}'"
     common = common_sdk_kwargs(doc, index, report, context)
 
-    parent_container = None
     if doc.container is not None:
         if not index.has_container(doc.container):
             report.report_dangling_reference(
@@ -107,7 +106,10 @@ def build_dataset(
                 f"(platform={doc.container.platform}, database={doc.container.database}, "
                 f"schema={doc.container.schema_name})"
             )
-        parent_container = container_key(doc.container)
+        # `parent_container=` defaults to a private `Unset` sentinel, not `None`;
+        # passing `None` emits an unwanted empty `browsePathsV2` (see _PLANNING.md).
+        # Only include it when a container is actually declared -- same as chart.py.
+        common["parent_container"] = container_key(doc.container)
 
     schema_metadata = None
     if doc.schema_block is not None:
@@ -124,7 +126,6 @@ def build_dataset(
         display_name=doc.displayName,
         external_url=doc.externalUrl,
         custom_properties=stringify_custom_properties(doc.properties),
-        parent_container=parent_container,
         schema=schema_metadata,
         upstreams=upstreams,
         view_definition=(build_view_properties(doc.viewProperties) if doc.viewProperties else None),

--- a/src/datahub_yaml_source/builders/glossary.py
+++ b/src/datahub_yaml_source/builders/glossary.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import DisplayPropertiesClass
+from datahub.metadata.urns import GlossaryTermUrn
 from datahub.sdk.glossary_node import GlossaryNode
 from datahub.sdk.glossary_term import GlossaryTerm
 
@@ -26,10 +27,12 @@ def _resolve_related_term_urns(
     report: YamlSourceReport,
     context: str,
     relation: str,
-) -> list[str] | None:
+) -> list[str | GlossaryTermUrn] | None:
+    # Returns URN strings; the `str | GlossaryTermUrn` element type just matches
+    # `GlossaryTerm`'s constructor params (a `list[str]` won't assign to them).
     if not term_ids:
         return None
-    urns = []
+    urns: list[str | GlossaryTermUrn] = []
     for term_id in term_ids:
         if not index.has_glossary_term(term_id):
             report.report_dangling_reference(

--- a/src/datahub_yaml_source/loader.py
+++ b/src/datahub_yaml_source/loader.py
@@ -17,7 +17,7 @@ reason.
 import logging
 import os
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -316,7 +316,7 @@ def discover_yaml_files(root: str | Path, aws_connection: Any | None = None) -> 
 
 
 def load_repository(
-    roots: str | Path | list[str | Path],
+    roots: str | Path | Sequence[str | Path],
     on_error: OnErrorCallback,
     on_file_scanned: OnFileScannedCallback | None = None,
     on_unknown_fields: OnUnknownFieldsCallback | None = None,
@@ -334,7 +334,7 @@ def load_repository(
     `on_unknown_fields` and still processed, ignoring only that field.
     """
     repository = ParsedRepository()
-    root_list = roots if isinstance(roots, list) else [roots]
+    root_list = [roots] if isinstance(roots, str | Path) else list(roots)
 
     seen_uris: set = set()
     for root in root_list:

--- a/src/datahub_yaml_source/models.py
+++ b/src/datahub_yaml_source/models.py
@@ -9,7 +9,7 @@ These models only describe the on-disk shape of the YAML. Translation into
 DataHub aspects/URNs happens in `datahub_yaml_source.builders.*`.
 """
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
@@ -1272,10 +1272,6 @@ class AIAgentDependenciesDoc(BaseModel):
     )
 
 
-class DisplayPropertiesDoc(BaseModel):
-    colorHex: str | None = None
-
-
 class RepositoryDoc(
     HasOwners,
     HasTags,
@@ -1717,7 +1713,7 @@ class RawAspectDoc(BaseModel):
     entityUrn: str | None = None
 
 
-ENTITY_DOC_TYPES_BY_KIND = {
+ENTITY_DOC_TYPES_BY_KIND: dict[str, type[BaseModel]] = {
     "DATA_PLATFORM": DataPlatformDoc,
     "TAG": TagDoc,
     "GLOSSARY_NODE": GlossaryNodeDoc,
@@ -1804,7 +1800,9 @@ def parse_document(raw: dict[str, Any]) -> ParsedDoc:
             raise DocumentParseError(
                 f"Unknown kind '{kind}'. Supported kinds: {sorted(ENTITY_DOC_TYPES_BY_KIND)}"
             )
-        return model_cls.model_validate(raw)
+        # `ENTITY_DOC_TYPES_BY_KIND` maps each kind to its own `EntityDoc` member;
+        # that value type can't be expressed as a useful mypy annotation on the dict.
+        return cast("ParsedDoc", model_cls.model_validate(raw))
 
     if "aspectName" in raw:
         return RawAspectDoc.model_validate(raw)

--- a/src/datahub_yaml_source/urns.py
+++ b/src/datahub_yaml_source/urns.py
@@ -11,6 +11,8 @@ emit a warning about a dangling reference (e.g. a `tags: [nope]` pointing at
 a tag that was never declared as its own `TAG` document).
 """
 
+from typing import Protocol
+
 from datahub.emitter.mce_builder import (
     make_data_platform_urn,
     make_dataplatform_instance_urn,
@@ -55,11 +57,7 @@ from datahub_yaml_source.models import (
     DashboardRef,
     DataFlowJobRef,
     DataFlowRef,
-    DatasetFieldRef,
-    DatasetRef,
-    MLFeatureRef,
     MLModelGroupRef,
-    MLPrimaryKeyRef,
 )
 
 
@@ -69,7 +67,23 @@ def _passthrough_if_urn(value: str, build) -> str:
     return build(value)
 
 
-def dataset_urn(ref: DatasetRef | DatasetFieldRef) -> str:
+# Structural types: the URN helpers only read a handful of fields, and both the
+# `*Ref` reference models and the full `*Doc` documents carry them. Typing the
+# helpers against these Protocols lets a builder pass whichever it already holds
+# without a conversion step (see _PLANNING.md "reference-resolution strategy").
+class _DatasetKeyLike(Protocol):
+    platform: str
+    name: str
+    instance: str | None
+    env: str
+
+
+class _MLFeatureKeyLike(Protocol):
+    featureNamespace: str
+    name: str
+
+
+def dataset_urn(ref: _DatasetKeyLike) -> str:
     return make_dataset_urn_with_platform_instance(
         platform=ref.platform,
         name=ref.name,
@@ -155,11 +169,11 @@ def ml_feature_table_urn(ref) -> str:
     return MlFeatureTableUrn(ref.platform, ref.name).urn()
 
 
-def ml_feature_urn(ref: MLFeatureRef) -> str:
+def ml_feature_urn(ref: _MLFeatureKeyLike) -> str:
     return MlFeatureUrn(ref.featureNamespace, ref.name).urn()
 
 
-def ml_primary_key_urn(ref: MLPrimaryKeyRef) -> str:
+def ml_primary_key_urn(ref: _MLFeatureKeyLike) -> str:
     return MlPrimaryKeyUrn(ref.featureNamespace, ref.name).urn()
 
 

--- a/src/datahub_yaml_source/yaml_source.py
+++ b/src/datahub_yaml_source/yaml_source.py
@@ -162,6 +162,9 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
         to check locally, and `load_repository()` reports any listing/read
         problem for them itself, per-URI, via `on_error`.
         """
+        # `path` is `str | list[str]` here: YamlSourceConfig's model validator
+        # (`_default_path_and_require_source`) has already defaulted or rejected None.
+        assert self.config.path is not None
         configured_paths = (
             self.config.path if isinstance(self.config.path, list) else [self.config.path]
         )
@@ -542,6 +545,8 @@ class YamlSource(StatefulIngestionSourceBase, TestableSource):
                 return test_report
 
             problems = []
+            # See the note in `get_workunits_internal`: `path` is non-None post-validation.
+            assert config.path is not None
             entries = config.path if isinstance(config.path, list) else [config.path]
             for entry in entries:
                 if is_s3_uri(entry):

--- a/tests/unit/test_builders_extended.py
+++ b/tests/unit/test_builders_extended.py
@@ -306,6 +306,7 @@ def test_build_assertion_custom():
                 "type": "CUSTOM",
                 "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,x,PROD)",
                 "customType": "GREAT_EXPECTATIONS",
+                "fieldPath": "patient_id",
                 "logic": "expect_column_values_to_not_be_null(patient_id)",
             },
         }
@@ -317,6 +318,31 @@ def test_build_assertion_custom():
     aspect = wus[0].metadata.aspect
     assert aspect.customAssertion.type == "GREAT_EXPECTATIONS"
     assert "not_be_null" in aspect.customAssertion.logic
+    # `field` is a schemaField URN string (not a SchemaFieldSpec), derived from
+    # the dataset URN + the column path.
+    assert aspect.customAssertion.field == (
+        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,x,PROD),patient_id)"
+    )
+
+
+def test_build_assertion_custom_without_field():
+    doc = AssertionDoc.model_validate(
+        {
+            "kind": "ASSERTION",
+            "id": "id8b",
+            "assertion": {
+                "type": "CUSTOM",
+                "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,x,PROD)",
+                "customType": "GREAT_EXPECTATIONS",
+                "logic": "row_count > 0",
+            },
+        }
+    )
+    repo = ParsedRepository()
+    index = ReferenceIndex(repo)
+    report = YamlSourceReport()
+    wus = list(build_assertion(doc, index, report))
+    assert wus[0].metadata.aspect.customAssertion.field is None
 
 
 def test_build_assertion_emits_note_and_actions():


### PR DESCRIPTION
Drives the mypy baseline **31 → 0** and flips the job to blocking. Every error fixed with a real annotation, guard, `cast`, or code fix — **no `# type: ignore`, no baseline file**.

## The 31, by cluster

| Cluster | Fix |
|---|---|
| **A** `list[str]` where SDK types `list[str \| SomeUrn]` (glossary related-terms ×4, DataJob inlets/outlets ×2) | Widened the helper return / local annotations — `str` is a valid member of `str \| Urn`, so no lie |
| **B** `str \| None` reaching `list[str]` / `str` (`yaml_source.py` ×2, `assertion.py` field) | `assert config.path is not None` documenting `YamlSourceConfig`'s validator invariant; the assertion one was a **real bug** (see below) |
| **C** `*Doc` passed where `*Ref` typed (`ml.py` ×2, `dataset.py`, `application.py`) | Structural `Protocol`s (`_DatasetKeyLike`, `_MLFeatureKeyLike`) in `urns.py`; `application.py` also got `assert edge.dataset is not None` after its exactly-one-of check |
| **D** `AssertionInfoClass(**payload)` ×9 | Intermediate `dict[str, Any]` for the runtime-chosen sub-assertion kwarg |
| **E** `NaturalKey` 5-tuple alias vs real 3-tuple | Aligned the alias to `container_natural_key()` |
| **F** misc | duplicate `DisplayPropertiesDoc` deleted · `ENTITY_DOC_TYPES_BY_KIND` → `dict[str, type[BaseModel]]` + `cast` to `ParsedDoc` · `_TYPE_MAP` explicit union · `load_repository` roots → `Sequence` · `types-PyYAML` in the `dev` extra · `dataset.py` `parent_container` now conditional in `common` (passing `None` emits a spurious empty `browsePathsV2` — `_PLANNING.md`'s "two traps" note claimed `dataset.py` already followed the pattern; it didn't) |

## Genuine bug fixed

`_build_custom_assertion` passed a `SchemaFieldSpecClass` to `CustomAssertionInfoClass(field=...)`, which wants a **schemaField URN string**. Now `make_schema_field_urn(entityUrn, fieldPath)`. No fixture exercised CUSTOM + `fieldPath`, so the golden is unchanged; two unit tests added (`with`/`without` field).

## Generated docs/schema

Deleting the duplicate `DisplayPropertiesDoc` also removed a mangled `datahub_yaml_source__models__DisplayPropertiesDoc__2` `$ref` (no description) from the JSON schema — regenerated, net −16 lines, and the markdown now links the type properly.

## Making it blocking

- `quality.yml`: `mypy (advisory)` → `mypy`, `continue-on-error` removed.
- `spec-process-cicd-quality.md` → **1.2** (mypy blocking, baseline zero, error-handling / gates / VLD-003 updated).
- `spec-process-cicd-ci.md` → **1.6** (`mypy` added to `main`'s required status checks).
- `CONTRIBUTING.md`: "advisory" → "blocking, baseline zero".

## Needs you

Add `mypy` to `main`'s required status checks (now `CI status`, `ruff`, `mypy`):

```
! echo '{"required_status_checks":{"strict":false,"contexts":["CI status","ruff","mypy"]},"enforce_admins":false,"required_pull_request_reviews":null,"restrictions":null}' | gh api --method PUT repos/davidouagne/datahub-yaml-source/branches/main/protection --input -
```

The wayfinder map (#1) "Not yet specified" line *"Critère/calendrier pour promouvoir mypy d'advisory à bloquant"* is now moot — safe to trim.

Verified locally: `mypy` clean (0 / 30 files), `ruff` + `ruff format` clean, 211 tests pass (on `acryl-datahub 1.7.0.10`).

Resolves #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
