### PR TITLE
docs: note sink mode: ASYNC for structured-property define+assign trees

### DIFF
--- a/docs/sources/yaml/yaml.md
+++ b/docs/sources/yaml/yaml.md
@@ -381,3 +381,15 @@ types, defaults), see the generated [reference.md](reference.md).
 - **"Glob patterns are not supported for http(s):// URIs"**: an `http(s)://`
   entry in `path` has no directory listing — it must be the URL of a single
   YAML file, not a wildcard.
+- **Structured-property writes rejected: "no valid property assignments remain
+  after removing values for non-existent properties: [...]"**: this tree both
+  defines a structured property (`kind: STRUCTURED_PROPERTY`) and assigns it
+  (`structuredProperties:` on some document), and the `datahub-rest` sink's
+  default `mode: ASYNC_BATCH` packed the definition and an assignment
+  referencing it into the same atomic write batch. GMS validates the batch
+  against already-committed state, so the assignment fails and the whole batch
+  — definition included — is rejected. Set `mode: ASYNC` on the sink (one MCP
+  at a time, in order) so each definition lands before its assignment. The
+  source emits all definitions before any assignment already; this is purely a
+  sink batching effect, and large trees often avoid it by chance (early batches
+  fill up with definitions) while small ones don't.

--- a/docs/sources/yaml/yaml_recipe.yml
+++ b/docs/sources/yaml/yaml_recipe.yml
@@ -104,3 +104,12 @@ sink:
   type: datahub-rest
   config:
     server: http://localhost:8080
+    # If this tree both *defines* structured properties (kind: STRUCTURED_PROPERTY)
+    # and *assigns* them (structuredProperties: on other documents), set
+    # mode: ASYNC. The default ASYNC_BATCH can pack a property definition and an
+    # assignment that references it into the same atomic write batch; GMS then
+    # rejects the batch ("no valid property assignments remain ... non-existent
+    # properties"), losing the definition too. ASYNC sends one MCP at a time in
+    # order, so the definition lands before the assignment. Large trees usually
+    # avoid this by luck (definitions fill whole early batches); small ones don't.
+    # mode: ASYNC


### PR DESCRIPTION
Resolves wayfinder ticket **T8 — Structured-property ordering vs GMS live + UI checklist** (#38), child of the release map #28.

### What T8 found
Running the connector end-to-end against a live GMS (local quickstart, part of T5 #33):

- The source emits **every** `STRUCTURED_PROPERTY.propertyDefinition` before any `structuredProperties:` assignment — emit order is correct, golden test (file sink) is green.
- But the `datahub-rest` sink's default `mode: ASYNC_BATCH` packs a definition and an assignment referencing it into the **same atomic write batch**. GMS validates the batch against already-committed state, the assignment fails ("no valid property assignments remain … non-existent properties"), and the whole batch — definition included — is 422'd.
- `mode: ASYNC` (one MCP at a time, in order) → **fully clean**: the integration-fixture tree ingests with 272 records, 0 failures.
- `aphp/datahub-sample` never hits this (64 definitions fill whole early batches before any assignment batch is validated) — it ingested 100 % clean in T5.

So: **not a connector code bug, not a GMS-version limitation** — a sink batching effect, fixed by config.

### This PR
- `yaml.md`: a Troubleshooting entry for the symptom + `mode: ASYNC` fix.
- `yaml_recipe.yml`: a commented `mode: ASYNC` line in the sink block with the rationale.

No code change. `test_json_schema_generation` / `test_markdown_docs_generation` green (no model change).

### Also verified under T8 (not in this PR)
The 10-point UI checklist from `_PLANNING.md` step 5, aspect-by-aspect against the local GMS (fixture ingested with `mode: ASYNC` + `aphp/datahub-sample` from T5): **10/10 pass** — structured property value, deprecation, links, nested domain (`parentDomain` → URN), PII tag on the `schemaField` entity, job→job `inputDatajobs`, dashboard `chartEdges`, query `querySubjects` → `schemaField`, incident `source.sourceUrn` → assertion, native document with text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)