### PR TITLE
ci: upload coverage to Codecov from the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
     name: test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Job-level permissions REPLACE the workflow-level grant, they do not
+    # merge -- so `contents: read` is restated here alongside the
+    # `id-token: write` that Codecov's OIDC upload needs. Only this job
+    # gets it; see spec/spec-process-cicd-codecov.md (SEC-002) and the
+    # Security Controls note in spec/spec-process-cicd-ci.md.
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -56,8 +64,22 @@ jobs:
       - name: Run tests with coverage
         run: |
           python -m pytest tests/unit tests/integration \
-            --cov=datahub_yaml_source --cov-report=term-missing \
+            --cov=datahub_yaml_source --cov-report=term-missing --cov-report=xml \
             --cov-fail-under=80
+
+      # Reporting only -- Codecov never gates `main`; --cov-fail-under=80
+      # above is the coverage gate. All three matrix legs upload, tagged by
+      # Python version; Codecov merges them. OIDC auth (no CODECOV_TOKEN).
+      # `fail_ci_if_error: false` + `if: always()`: a Codecov outage, or a
+      # fork PR with no OIDC token, must never fail this job or `CI status`.
+      # Contract: spec/spec-process-cicd-codecov.md
+      - name: Upload coverage to Codecov
+        if: ${{ always() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: py${{ matrix.python-version }}
+          fail_ci_if_error: false
 
   minimal-install-check:
     name: minimal install (no extras)

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .coverage
+coverage.xml
 *.egg-info/
 *.stackdump
 build/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+# Codecov behaviour for datahub-yaml-source.
+#
+# Reporting only: Codecov is NOT a required check on `main`. The coverage
+# gate is `pytest --cov-fail-under=80` in .github/workflows/ci.yml. Both
+# `project` and `patch` statuses are `informational`, so Codecov posts a
+# number but never a red X that blocks merge.
+#
+# Design contract: spec/spec-process-cicd-codecov.md
+
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  # `flags` in the layout is why all three Python matrix legs upload.
+  layout: "reach, diff, flags, files"
+  require_changes: true       # stay quiet on PRs that don't move coverage
+  after_n_builds: 3           # wait for py3.10 + py3.11 + py3.12 before settling
+
+github_checks:
+  annotations: false          # no inline "line not covered" marks on the diff

--- a/spec/spec-process-cicd-ci.md
+++ b/spec/spec-process-cicd-ci.md
@@ -1,6 +1,6 @@
 ---
 title: CI/CD Workflow Specification - CI
-version: 1.7
+version: 1.8
 date_created: 2026-08-16
 last_updated: 2026-09-07
 owner: David Ouagne
@@ -287,6 +287,7 @@ the protection. Applied via `PUT /repos/davidouagne/datahub-yaml-source/branches
 | 1.5 | 2026-09-07 | Refreshed the `acryl-datahub` dependency-range Edge Case row: the floor is now `>=1.7.0.9,<1.8` (issue #12 lifted the `<1.7.0.5` stopgap and kept a `<1.8` bound). No workflow-file change. | David Ouagne |
 | 1.6 | 2026-09-07 | Added `mypy` to `main`'s required status checks (issue #13 promoted it to blocking). No workflow-file change in *this* spec's scope (`ci.yml` untouched). | David Ouagne |
 | 1.7 | 2026-09-07 | The `test` job will also emit `coverage.xml` (`--cov-report=xml`) and upload it to Codecov via `codecov/codecov-action` using GitHub OIDC (`id-token: write` on `test`; no stored token). Reporting only — no new required check, `--cov-fail-under=80` unchanged. Contract in the new `spec/spec-process-cicd-codecov.md`; the `ci.yml` change itself is deferred to wayfinder map issue #40's wiring ticket. This revision records the Secrets/Outputs/Security-Controls/Edge-Case impact and refreshes the stale "None yet" Related Specifications stub. | David Ouagne |
+| 1.8 | 2026-09-07 | Workflow-file change: the `test` job now runs `pytest ... --cov-report=xml`, sets job-level `permissions: {contents: read, id-token: write}`, and has a `codecov/codecov-action@v5` upload step (`use_oidc: true`, `flags: py${{ matrix.python-version }}`, `fail_ci_if_error: false`, `if: always()`). Implements what 1.7 specified; `spec/spec-process-cicd-codecov.md` → 1.1 in the same change. `CI status` still aggregates only `test` + `minimal-install-check`; the Codecov step cannot fail the job. | David Ouagne |
 
 ## Related Specifications
 

--- a/spec/spec-process-cicd-codecov.md
+++ b/spec/spec-process-cicd-codecov.md
@@ -1,6 +1,6 @@
 ---
 title: CI/CD Workflow Specification - Coverage Reporting (Codecov)
-version: 1.0
+version: 1.1
 date_created: 2026-09-07
 last_updated: 2026-09-07
 owner: David Ouagne
@@ -22,13 +22,13 @@ request targeting `main`; manual dispatch).
 
 **Target Environments**: None. Reporting only, no deployment target.
 
-> **Status**: The `.github/workflows/ci.yml` integration this document specifies is
-> **not yet implemented**. It lands in the wayfinder wiring ticket (map issue #40,
-> child "Wire codecov-action into the test job + commit codecov.yml"). Until that
-> merges, this document is the contract that change must satisfy, not a description
-> of a running integration. The Codecov side is already provisioned: the Codecov
-> GitHub App is installed on `davidouagne/datahub-yaml-source`, auth is GitHub
-> OIDC, and no upload token is stored (map issue #40, "Provision Codecov").
+> **Status**: Implemented — the upload step lives in `.github/workflows/ci.yml`'s
+> `test` job and `codecov.yml` sits at the repo root. This document is the design
+> contract those must satisfy; changes to either should keep the other in sync,
+> per Change Management below. The Codecov side is provisioned: the Codecov GitHub
+> App is installed on `davidouagne/datahub-yaml-source`, auth is GitHub OIDC, and
+> no upload token is stored. The README badge is added separately (map issue #40,
+> "README: add Codecov badge to the badge row").
 
 ## Execution Flow Diagram
 
@@ -48,14 +48,14 @@ graph TD
 
 ## Configuration (authoritative pointers)
 
-Two configuration surfaces, both landing in the wiring ticket:
+Two configuration surfaces:
 
 1. The upload step in `.github/workflows/ci.yml` (the `test` job).
 2. `codecov.yml` at the repository root — Codecov's own behaviour (commit
-   statuses, PR comment). Once committed, that file is authoritative for
-   everything in the "`codecov.yml` contents" table below; this spec records the
-   intent and rationale, the same way `spec/spec-process-cicd-ci.md` records the
-   intent behind `ci.yml`.
+   statuses, PR comment). That file is authoritative for everything in the
+   "`codecov.yml` contents" table below; this spec records the intent and
+   rationale, the same way `spec/spec-process-cicd-ci.md` records the intent
+   behind `ci.yml`.
 
 Codecov project settings live in the Codecov dashboard for
 `davidouagne/datahub-yaml-source`; this repo stores no Codecov API token, so they
@@ -97,8 +97,7 @@ python -m pytest tests/unit tests/integration \
 ```
 
 `coverage.xml` is written to the repo root and is a build artifact only — it is
-covered by `.gitignore` (`*.xml` is not currently ignored, so the wiring ticket
-adds a `coverage.xml` line).
+listed in `.gitignore`.
 
 | Setting | Value | Rationale |
 |---------|-------|-----------|
@@ -217,7 +216,7 @@ spec (drop `informational`) **and** a `main` branch-protection change
 
 ## Validation Criteria
 
-- **VLD-001**: After the wiring ticket merges, `.github/workflows/ci.yml`'s `test` job contains a `codecov/codecov-action@v5` step with `use_oidc: true`, `flags: py${{ matrix.python-version }}`, `fail_ci_if_error: false`, and a job-level `permissions` block granting `contents: read` **and** `id-token: write`.
+- **VLD-001**: `.github/workflows/ci.yml`'s `test` job contains a `codecov/codecov-action@v5` step with `use_oidc: true`, `flags: py${{ matrix.python-version }}`, `fail_ci_if_error: false`, and a job-level `permissions` block granting `contents: read` **and** `id-token: write`.
 - **VLD-002**: The pytest command in the `test` job passes `--cov-report=xml` alongside the existing `--cov-report=term-missing` and `--cov-fail-under=80`.
 - **VLD-003**: `codecov.yml` at the repo root sets `project` and `patch` statuses to `informational: true`, `comment.after_n_builds: 3`, `comment.require_changes: true`, `github_checks.annotations: false`.
 - **VLD-004**: `gh api repos/davidouagne/datahub-yaml-source/branches/main/protection` does not list any `codecov/*` context.
@@ -247,6 +246,7 @@ branch-protection change:
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
 | 1.0 | 2026-09-07 | Initial specification. Codecov as **reporting-only** coverage publishing appended to CI's `test` job: `codecov/codecov-action@v5`, GitHub OIDC (`use_oidc: true`, `id-token: write` on `test`, no stored token), upload from all three Python matrix legs with `flags`, `fail_ci_if_error: false`. `codecov.yml` sets `project` / `patch` statuses `informational`, PR comment after 3 builds on change only, diff annotations off. `pytest --cov-fail-under=80` remains the coverage gate (`spec/spec-process-cicd-ci.md` REQ-004); no `codecov/*` check is required on `main`. Workflow, `codecov.yml`, and README changes land in a separate wiring ticket (wayfinder map issue #40). | David Ouagne |
+| 1.1 | 2026-09-07 | Implemented: the `codecov/codecov-action@v5` step and job-level `id-token: write` are in `ci.yml`'s `test` job, `--cov-report=xml` added to the pytest call, `codecov.yml` committed at the repo root, `coverage.xml` added to `.gitignore`. Status banner flipped from "not yet implemented" to "implemented"; future-tense wording in Configuration / VLD-001 made present-tense. README badge still pending (map issue #40). `ci.md` → 1.8 in the same change. | David Ouagne |
 
 ## Related Specifications
 


### PR DESCRIPTION
Resolves the wiring ticket on the **add Codecov** wayfinder map (issue #40): [Wire codecov-action into the test job + commit codecov.yml](https://github.com/davidouagne/datahub-yaml-source/issues/43). Implements the contract from [spec-process-cicd-codecov.md](https://github.com/davidouagne/datahub-yaml-source/blob/main/spec/spec-process-cicd-codecov.md) (merged in #45).

## Changes

- **`.github/workflows/ci.yml`** — `test` job:
  - pytest gains `--cov-report=xml` (keeps `term-missing` + `--cov-fail-under=80`).
  - job-level `permissions: {contents: read, id-token: write}` — job-level permissions *replace* the workflow default, so `contents: read` is restated. Only this job gets `id-token: write`.
  - `codecov/codecov-action@v5` step: `use_oidc: true`, `flags: py${{ matrix.python-version }}`, `fail_ci_if_error: false`, `if: always()`. No `CODECOV_TOKEN`.
- **`codecov.yml`** (new) — `project`/`patch` statuses `informational` (never a gate), PR comment `after_n_builds: 3` + `require_changes: true`, `github_checks.annotations: false`.
- **`.gitignore`** — `coverage.xml`.
- **Specs** — `spec-process-cicd-codecov.md` 1.0 → 1.1 (status → "implemented", future tense removed); `spec-process-cicd-ci.md` 1.7 → 1.8 (workflow-file change recorded).

## Verification

- Local: `pytest tests/unit tests/integration --cov-report=xml` → **211 passed**, `coverage.xml` written (Cobertura), total **97.37%**.
- On this PR, confirm: all 3 legs upload, the Codecov comment appears after the 3rd leg, and **`CI status` is green regardless** of the Codecov step. Fork-PR behaviour (upload no-ops, no OIDC token) can't be exercised from a same-repo branch — noted in the spec, to watch on the first external PR.
- Not touched: branch protection. No new required check.

Follow-up (blocked on this): [README: add Codecov badge to the badge row](https://github.com/davidouagne/datahub-yaml-source/issues/44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)